### PR TITLE
Dockerfile: migrated to dumb-init for fast container signals

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,8 +13,8 @@ on:
       - master
 
 env:
-  REGISTRY: docker.io
-  IMAGE_NAME: zerob13/mock-openai-api
+  REGISTRY: ghcr.io
+  IMAGE_NAME: f213/mock-openai-api
 
 jobs:
   build-and-push:
@@ -35,8 +35,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
@@ -69,4 +69,4 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: ${{ env.IMAGE_NAME }}
-          readme-filepath: ./README.md 
+          readme-filepath: ./README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # Build stage
 FROM node:22-alpine3.21
 
-
-# Install pages
+# Install dumb-init for proper signal handling
 RUN apk add --no-cache dumb-init==1.2.5-r3
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # Build stage
-FROM node:22-alpine
+FROM node:22-alpine3.21
+
+
+# Install pages
+RUN apk add --no-cache dumb-init==1.2.5-r3
 
 WORKDIR /app
 
@@ -24,6 +28,8 @@ ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOST=0.0.0.0
 ENV VERBOSE=true
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # Start the application with verbose logging enabled
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
Current container implemntation takes 10 secs to stop after pressing Ctrl-C. This happens because of node.js [not handling](https://github.com/Yelp/dumb-init?tab=readme-ov-file#why-you-need-an-init-system) docker signals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container base image to a newer Alpine variant for improved compatibility and security.
  * Added a lightweight init wrapper to improve signal handling and ensure clean shutdowns.
  * Switched image publishing from Docker Hub to GitHub Container Registry and updated authentication for CI publishing.
  * No user-facing application changes; deployment and CI improvements only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->