### PR TITLE
Expand mock API into three-provider protocol simulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22.12.0"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unreleased
+
+- Upgraded the server toward a deterministic three-provider protocol simulator for OpenAI-compatible, Anthropic-compatible, and Gemini-compatible agent harness development.
+- Added offline contract tests and gated SDK smoke tests. SDK smoke tests run only with `RUN_SDK_TESTS=1`.
+- Added shared mock infrastructure for scenarios, deterministic IDs, in-memory state, provider errors, SSE formatting, usage estimates, and fixtures.
+- Added OpenAI Responses API, modern Chat Completions state endpoints, embeddings, image edits/variations, and files support.
+- Added first-party Anthropic `/v1/messages`, token counting, streaming/tool/thinking scenarios, and Anthropic-shaped files support.
+- Added Gemini GenerateContent function calling, structured output, multimodal/file references, code execution/search mocks, files, cached contents, and countTokens support.
+- Added mock latency and stream chunk delay controls for client timing tests.
+- Added provider fixture seed examples and CI coverage for install, test, build, and lint.
+- Preserved legacy endpoints: `/models`, `/chat/completions`, `/images/generations`, `/anthropic/v1/models`, `/anthropic/v1/messages`, and `/gemini/v1/...` aliases.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,20 @@ When the server starts, it will display the configuration being used:
    • Port: 3000
    • Host: 0.0.0.0
    • Verbose logging: DISABLED
-   • Version: 1.0.1
+   • Config file: ./model-mapping.json
+   • Version: 1.0.6
+📖 API Documentation:
+   OpenAI compatible:
+   • POST /v1/responses - Responses API create/stream/tool calls
+   • POST /v1/chat/completions - Chat Completions create/stream/tool calls
+   • POST /v1/embeddings - Deterministic embeddings
+   • POST /v1/files - Upload mock files
+   Anthropic compatible:
+   • POST /v1/messages - Messages create/stream/tool use/thinking
+   • POST /v1/messages/count_tokens - Message token counting
+   Gemini compatible:
+   • POST /v1beta/models/{model}:generateContent - GenerateContent
+   • POST /upload/v1beta/files - File upload, including SDK resumable upload
 ```
 
 ### Basic Usage
@@ -173,6 +186,14 @@ When the server starts, it will display the configuration being used:
 ```bash
 # Get model list
 curl http://localhost:3000/v1/models
+
+# Responses API
+curl -X POST http://localhost:3000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4.1-mini",
+    "input": "Hello from a local agent harness"
+  }'
 
 # Chat completion (non-streaming)
 curl -X POST http://localhost:3000/v1/chat/completions \
@@ -220,21 +241,59 @@ curl -X POST http://localhost:3000/v1/images/generations \
 ## 📋 Supported API Endpoints
 
 ### OpenAI Compatible Endpoints
-- `GET /v1/models` - Get available model list
+- `GET /v1/models` - Get available OpenAI-compatible model list by default
 - `GET /models` - Compatible endpoint
+- `POST /v1/responses` - Create a deterministic Responses API response
+- `GET /v1/responses/{response_id}` - Retrieve a stored response
+- `DELETE /v1/responses/{response_id}` - Delete a stored response
+- `POST /v1/responses/{response_id}/cancel` - Cancel a queued/in-progress response
+- `GET /v1/responses/{response_id}/input_items` - List stored input items
+- `POST /v1/responses/input_tokens` - Count response input tokens
+- `POST /v1/responses/compact` - Return a compacted mock context response
 - `POST /v1/chat/completions` - Create chat completion
+- `GET /v1/chat/completions/{completion_id}` - Retrieve a stored chat completion
+- `POST /v1/chat/completions/{completion_id}` - Update stored chat completion metadata
+- `DELETE /v1/chat/completions/{completion_id}` - Delete a stored chat completion
+- `GET /v1/chat/completions/{completion_id}/messages` - List stored chat messages
 - `POST /chat/completions` - Compatible endpoint
 - `POST /v1/images/generations` - Generate images
+- `POST /v1/images/edits` - Generate deterministic image edit results
+- `POST /v1/images/variations` - Generate deterministic image variation results
 - `POST /images/generations` - Compatible endpoint
+- `POST /v1/embeddings` - Create deterministic embedding vectors
+- `POST /v1/files` - Upload a mock file
+- `GET /v1/files` - List uploaded mock files
+- `GET /v1/files/{file_id}` - Retrieve mock file metadata
+- `DELETE /v1/files/{file_id}` - Delete a mock file
 
 ### Anthropic Compatible Endpoints
+- `GET /v1/models` - Get Anthropic model list when `anthropic-version` or `x-provider: anthropic` is set
 - `GET /anthropic/v1/models` - Get Anthropic model list
+- `POST /v1/messages` - Create a Claude-compatible message
 - `POST /anthropic/v1/messages` - Create message (Claude API)
+- `POST /v1/messages/count_tokens` - Count Claude-compatible message tokens
+- `POST /v1/files` - Upload an Anthropic-shaped mock file when `anthropic-version` or `x-provider: anthropic` is set
+- `GET /v1/files` - List Anthropic-shaped mock files with Anthropic provider headers
+- `GET /v1/files/{file_id}` - Retrieve Anthropic-shaped mock file metadata with Anthropic provider headers
+- `DELETE /v1/files/{file_id}` - Delete Anthropic-shaped mock files with Anthropic provider headers
 
 ### Gemini Compatible Endpoints
+- `GET /v1/models` - Get Gemini model list when `x-provider: gemini` or `?provider=gemini` is set
 - `GET /v1beta/models` - Get Gemini model list
 - `POST /v1beta/models/{model}:generateContent` - Generate content
 - `POST /v1beta/models/{model}:streamGenerateContent` - Generate content (streaming)
+- `POST /v1beta/models/{model}:countTokens` - Count Gemini request tokens
+- `POST /upload/v1beta/files` - Upload a Gemini mock file
+- `GET /v1beta/files` - List Gemini mock files
+- `GET /v1beta/files/{name}` - Retrieve Gemini mock file metadata
+- `DELETE /v1beta/files/{name}` - Delete a Gemini mock file
+- `POST /v1beta/cachedContents` - Create a Gemini cached content record
+- `GET /v1beta/cachedContents` - List Gemini cached content records
+- `GET /v1beta/cachedContents/{name}` - Retrieve Gemini cached content metadata
+- `DELETE /v1beta/cachedContents/{name}` - Delete Gemini cached content
+- `GET /gemini/v1/models` - Legacy Gemini model list alias
+- `POST /gemini/v1/models/{model}/generateContent` - Legacy Gemini generate alias
+- `POST /gemini/v1/models/{model}/streamGenerateContent` - Legacy Gemini stream alias
 
 ### Health Check
 - `GET /health` - Server health status
@@ -371,38 +430,80 @@ npm start
 
 ```
 src/
-├── types/          # TypeScript type definitions
-├── data/           # Predefined test data
-├── utils/          # Utility functions
-├── services/       # Business logic services
-├── controllers/    # Route controllers
-├── routes/         # Route definitions
+├── core/           # Deterministic scenarios, errors, state, SSE, usage, validation
+├── providers/      # OpenAI, Anthropic, Gemini protocol routes and services
+├── fixtures/       # Provider fixture seeds for contribution examples
+├── data/           # Legacy predefined test data
+├── controllers/    # Legacy-compatible controllers
+├── routes/         # Route registration
 ├── app.ts          # Express app setup
 ├── index.ts        # Server startup
 └── cli.ts          # CLI tool entry
+
+test/
+├── contract/       # Offline endpoint contract tests
+├── unit/           # Core deterministic infrastructure tests
+└── sdk/            # Optional SDK smoke tests gated by RUN_SDK_TESTS=1
 ```
 
-### Adding New Test Scenarios
+### Mock Controls and Scenario Cookbook
 
-1. Add new test cases in `src/data/mockData.ts`
-2. You can add test cases for existing models or create new model types
-3. Rebuild the project: `npm run build`
+Every provider route is deterministic by default and can be steered with mock controls:
 
-Example:
+| Control | Location | Description |
+| --- | --- | --- |
+| `x-mock-scenario` / `mock_scenario` | header, query, or JSON body | Forces a supported scenario such as `tool_call`, `parallel_tools`, `structured_json`, `refusal`, `rate_limit`, or `invalid_request`. |
+| `x-mock-seed` | header | Makes generated IDs deterministic for repeatable tests. |
+| `x-mock-latency-ms` / `mock_latency_ms` | header, query, or JSON body | Adds endpoint latency before the handler runs. Values are capped at 30000 ms. |
+| `x-mock-stream-chunk-ms` / `mock_stream_chunk_ms` | header, query, or JSON body | Adds delay between provider SSE frames for streaming client tests. Values are capped at 30000 ms. |
+| `x-mock-error` / `mock_error` | header or query | Injects provider-shaped `400`, `401`, `403`, `404`, `409`, `429`, `500`, or `529` errors. |
+| `x-mock-background` | header | Creates queued/background OpenAI Responses where supported. |
 
-```typescript
-const newTestCase: MockTestCase = {
-  name: "New Feature Test",
-  description: "Description of new feature test",
-  prompt: "trigger keyword",
-  response: "Expected response content",
-  streamChunks: ["chunked", "streaming", "content"], // optional
-  functionCall: { // optional, only for function type models
-    name: "function_name",
-    arguments: { param: "value" }
-  }
-};
+Common scenarios:
+
+```bash
+# OpenAI Responses tool call
+curl -X POST http://localhost:3000/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "x-mock-scenario: tool_call" \
+  -d '{"model":"gpt-4.1-mini","input":"Look up order A100.","tools":[{"type":"function","name":"get_order"}]}'
+
+# Anthropic parallel tool use
+curl -X POST http://localhost:3000/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-mock-scenario: parallel_tools" \
+  -d '{"model":"claude-sonnet-4-5","max_tokens":256,"messages":[{"role":"user","content":"Check order and weather"}],"tools":[{"name":"get_order","input_schema":{"type":"object"}},{"name":"get_weather","input_schema":{"type":"object"}}]}'
+
+# Gemini structured JSON
+curl -X POST http://localhost:3000/v1beta/models/gemini-1.5-flash:generateContent \
+  -H "Content-Type: application/json" \
+  -d '{"contents":[{"role":"user","parts":[{"text":"Extract product data"}]}],"generationConfig":{"responseMimeType":"application/json","responseSchema":{"type":"OBJECT"}}}'
+
+# Provider-shaped injected error
+curl http://localhost:3000/v1beta/files -H "x-mock-error: 429"
+
+# Delayed stream chunks
+curl -N -X POST http://localhost:3000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "x-mock-stream-chunk-ms: 100" \
+  -d '{"model":"gpt-4.1-mini","stream":true,"messages":[{"role":"user","content":"Stream slowly"}]}'
 ```
+
+### Fixture Contributions
+
+Fixture seed examples live under:
+
+```txt
+src/fixtures/openai/
+src/fixtures/anthropic/
+src/fixtures/gemini/
+```
+
+Keep fixtures offline and deterministic: no real provider payloads copied from production, no live API calls, stable IDs/timestamps, and one focused contract or unit test for each new scenario. Runtime behavior is generated by provider services; fixture files are intentionally small examples for contributors and future fixture-store wiring.
+
+### Migration Note
+
+Legacy endpoints remain supported: `/models`, `/chat/completions`, `/images/generations`, `/anthropic/v1/models`, `/anthropic/v1/messages`, and `/gemini/v1/...` aliases continue to work while the newer provider-compatible `/v1/...` and `/v1beta/...` surfaces are expanded.
 
 ## 🌐 Deployment
 
@@ -671,6 +772,13 @@ curl https://mockllm.anya2a.com/v1/models \
 
 ### Testing with OpenAI SDK
 
+Local SDK smoke tests are gated so normal offline tests stay fast:
+
+```bash
+npm test
+RUN_SDK_TESTS=1 npm test -- test/sdk
+```
+
 ```javascript
 import OpenAI from 'openai';
 
@@ -715,6 +823,62 @@ const image = await client.images.generate({
 });
 
 console.log(image.data[0].url);
+```
+
+### Testing with Anthropic SDK
+
+```javascript
+import Anthropic from '@anthropic-ai/sdk';
+
+const anthropic = new Anthropic({
+  baseURL: 'http://localhost:3000',
+  apiKey: 'mock-key'
+});
+
+const message = await anthropic.messages.create({
+  model: 'claude-sonnet-4-5',
+  max_tokens: 256,
+  messages: [{ role: 'user', content: 'Hello' }],
+  tools: [{ name: 'get_order', input_schema: { type: 'object' } }]
+});
+
+console.log(message.content);
+
+const stream = anthropic.messages.stream({
+  model: 'claude-sonnet-4-5',
+  max_tokens: 256,
+  messages: [{ role: 'user', content: 'Stream hello' }]
+});
+
+console.log((await stream.finalMessage()).stop_reason);
+```
+
+### Testing with Google GenAI SDK
+
+```javascript
+import { GoogleGenAI } from '@google/genai';
+
+const ai = new GoogleGenAI({
+  apiKey: 'mock-key',
+  httpOptions: {
+    baseUrl: 'http://localhost:3000',
+    apiVersion: 'v1beta'
+  }
+});
+
+const response = await ai.models.generateContent({
+  model: 'gemini-1.5-flash',
+  contents: 'Hello'
+});
+
+console.log(response.text);
+
+const file = await ai.files.upload({
+  file: new Blob(['mock file'], { type: 'text/plain' }),
+  config: { mimeType: 'text/plain', displayName: 'mock.txt' }
+});
+
+console.log(file.uri);
 ```
 
 ## 🤝 Contributing

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,7 +9,7 @@
 
 *中文说明 | [English](README.md)*
 
-一个完整的 OpenAI API 兼容的模拟服务器，无需调用真实的大模型，返回预定义的测试数据。非常适合开发、测试和调试使用 OpenAI API 的应用程序。
+一个完整的 OpenAI、Anthropic、Gemini API 兼容模拟服务器，无需调用真实的大模型，返回确定性的本地测试数据。非常适合开发、测试和调试使用多家 AI API 的应用程序。
 
 ## 🚀 快速开始
 
@@ -110,7 +110,20 @@ npx mock-openai-api --help
    • Port: 3000
    • Host: 0.0.0.0
    • Verbose logging: DISABLED
-   • Version: 1.0.1
+   • Config file: ./model-mapping.json
+   • Version: 1.0.6
+📖 API Documentation:
+   OpenAI compatible:
+   • POST /v1/responses - Responses API 创建/流式/tool calls
+   • POST /v1/chat/completions - Chat Completions 创建/流式/tool calls
+   • POST /v1/embeddings - 确定性 embeddings
+   • POST /v1/files - 上传模拟文件
+   Anthropic compatible:
+   • POST /v1/messages - Messages 创建/流式/tool use/thinking
+   • POST /v1/messages/count_tokens - Message token 统计
+   Gemini compatible:
+   • POST /v1beta/models/{model}:generateContent - GenerateContent
+   • POST /upload/v1beta/files - 文件上传，兼容 SDK resumable upload
 ```
 
 ### 基本使用
@@ -118,6 +131,14 @@ npx mock-openai-api --help
 ```bash
 # 获取模型列表
 curl http://localhost:3000/v1/models
+
+# Responses API
+curl -X POST http://localhost:3000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4.1-mini",
+    "input": "本地 agent harness 测试"
+  }'
 
 # 聊天完成（非流式）
 curl -X POST http://localhost:3000/v1/chat/completions \
@@ -150,6 +171,8 @@ curl -X POST http://localhost:3000/v1/images/generations \
 ## 🎯 特性
 
 - ✅ **完整的 OpenAI API 兼容性**
+- ✅ **支持 Anthropic Claude API**
+- ✅ **支持 Google Gemini API**
 - ✅ **支持流式和非流式聊天完成**
 - ✅ **支持函数调用**
 - ✅ **支持图像生成**
@@ -160,17 +183,60 @@ curl -X POST http://localhost:3000/v1/images/generations \
 
 ## 📋 支持的 API 端点
 
-### 模型管理
-- `GET /v1/models` - 获取可用模型列表
+### OpenAI 兼容端点
+- `GET /v1/models` - 默认获取 OpenAI 兼容模型列表
 - `GET /models` - 兼容端点
-
-### 聊天完成
+- `POST /v1/responses` - 创建确定性的 Responses API 响应
+- `GET /v1/responses/{response_id}` - 获取已存储的响应
+- `DELETE /v1/responses/{response_id}` - 删除已存储的响应
+- `POST /v1/responses/{response_id}/cancel` - 取消排队/进行中的响应
+- `GET /v1/responses/{response_id}/input_items` - 列出响应输入项
+- `POST /v1/responses/input_tokens` - 统计响应输入 token
+- `POST /v1/responses/compact` - 返回确定性的上下文压缩响应
 - `POST /v1/chat/completions` - 创建聊天完成
+- `GET /v1/chat/completions/{completion_id}` - 获取已存储的聊天完成
+- `POST /v1/chat/completions/{completion_id}` - 更新聊天完成 metadata
+- `DELETE /v1/chat/completions/{completion_id}` - 删除已存储的聊天完成
+- `GET /v1/chat/completions/{completion_id}/messages` - 列出聊天消息
 - `POST /chat/completions` - 兼容端点
-
-### 图像生成
 - `POST /v1/images/generations` - 生成图像
+- `POST /v1/images/edits` - 生成确定性的图像编辑结果
+- `POST /v1/images/variations` - 生成确定性的图像变体结果
 - `POST /images/generations` - 兼容端点
+- `POST /v1/embeddings` - 创建确定性的 embedding 向量
+- `POST /v1/files` - 上传模拟文件
+- `GET /v1/files` - 列出模拟文件
+- `GET /v1/files/{file_id}` - 获取模拟文件 metadata
+- `DELETE /v1/files/{file_id}` - 删除模拟文件
+
+### Anthropic 兼容端点
+- `GET /v1/models` - 设置 `anthropic-version` 或 `x-provider: anthropic` 时返回 Anthropic 模型列表
+- `GET /anthropic/v1/models` - 获取 Anthropic 模型列表
+- `POST /v1/messages` - 创建 Claude 兼容消息
+- `POST /anthropic/v1/messages` - 兼容消息端点
+- `POST /v1/messages/count_tokens` - 统计 Claude 兼容消息 token
+- `POST /v1/files` - 设置 Anthropic provider header 时上传 Anthropic 形状的模拟文件
+- `GET /v1/files` - 设置 Anthropic provider header 时列出 Anthropic 形状的模拟文件
+- `GET /v1/files/{file_id}` - 设置 Anthropic provider header 时获取文件 metadata
+- `DELETE /v1/files/{file_id}` - 设置 Anthropic provider header 时删除文件
+
+### Gemini 兼容端点
+- `GET /v1/models` - 设置 `x-provider: gemini` 或 `?provider=gemini` 时返回 Gemini 模型列表
+- `GET /v1beta/models` - 获取 Gemini 模型列表
+- `POST /v1beta/models/{model}:generateContent` - 生成内容
+- `POST /v1beta/models/{model}:streamGenerateContent` - 流式生成内容
+- `POST /v1beta/models/{model}:countTokens` - 统计 Gemini 请求 token
+- `POST /upload/v1beta/files` - 上传 Gemini 模拟文件
+- `GET /v1beta/files` - 列出 Gemini 模拟文件
+- `GET /v1beta/files/{name}` - 获取 Gemini 文件 metadata
+- `DELETE /v1beta/files/{name}` - 删除 Gemini 模拟文件
+- `POST /v1beta/cachedContents` - 创建 Gemini cached content
+- `GET /v1beta/cachedContents` - 列出 Gemini cached contents
+- `GET /v1beta/cachedContents/{name}` - 获取 Gemini cached content metadata
+- `DELETE /v1beta/cachedContents/{name}` - 删除 Gemini cached content
+- `GET /gemini/v1/models` - 旧版 Gemini 模型别名
+- `POST /gemini/v1/models/{model}/generateContent` - 旧版 Gemini 生成别名
+- `POST /gemini/v1/models/{model}/streamGenerateContent` - 旧版 Gemini 流式别名
 
 ### 健康检查
 - `GET /health` - 服务器健康状态
@@ -266,38 +332,77 @@ npm start
 
 ```
 src/
-├── types/          # TypeScript 类型定义
-├── data/           # 预定义的测试数据
-├── utils/          # 工具函数
-├── services/       # 业务逻辑服务
-├── controllers/    # 路由控制器
-├── routes/         # 路由定义
+├── core/           # 确定性场景、错误、状态、SSE、usage、校验
+├── providers/      # OpenAI、Anthropic、Gemini 协议路由和服务
+├── fixtures/       # provider fixture 示例
+├── data/           # 旧版预定义测试数据
+├── controllers/    # 旧版兼容 controller
+├── routes/         # 路由注册
 ├── app.ts          # Express 应用设置
 ├── index.ts        # 服务器启动
 └── cli.ts          # CLI 工具入口
+
+test/
+├── contract/       # 离线端点契约测试
+├── unit/           # 核心确定性基础设施测试
+└── sdk/            # 通过 RUN_SDK_TESTS=1 开启的 SDK smoke tests
 ```
 
-### 添加新的测试场景
+### Mock 控制项与场景速查
 
-1. 在 `src/data/mockData.ts` 中添加新的测试用例
-2. 可以为现有模型添加测试用例，或创建新的模型类型
-3. 重新构建项目：`npm run build`
+默认响应都是确定性的，也可以用 mock 控制项指定场景：
 
-示例：
+| 控制项 | 位置 | 说明 |
+| --- | --- | --- |
+| `x-mock-scenario` / `mock_scenario` | header、query 或 JSON body | 强制场景，例如 `tool_call`、`parallel_tools`、`structured_json`、`refusal`、`rate_limit`、`invalid_request`。 |
+| `x-mock-seed` | header | 固定生成 ID，便于重复测试。 |
+| `x-mock-latency-ms` / `mock_latency_ms` | header、query 或 JSON body | 在 handler 执行前添加端点延迟，最大 30000 ms。 |
+| `x-mock-stream-chunk-ms` / `mock_stream_chunk_ms` | header、query 或 JSON body | 为 provider SSE 帧之间添加延迟，用于测试流式客户端，最大 30000 ms。 |
+| `x-mock-error` / `mock_error` | header 或 query | 注入 provider 形状的 `400`、`401`、`403`、`404`、`409`、`429`、`500`、`529` 错误。 |
+| `x-mock-background` | header | 在支持的 OpenAI Responses 路由中创建 queued/background 响应。 |
 
-```typescript
-const newTestCase: MockTestCase = {
-  name: "新功能测试",
-  description: "测试新功能的描述",
-  prompt: "触发关键词",
-  response: "预期的响应内容",
-  streamChunks: ["分段", "流式", "内容"], // 可选
-  functionCall: { // 可选，仅用于 function 类型模型
-    name: "function_name",
-    arguments: { param: "value" }
-  }
-};
+常用场景：
+
+```bash
+# OpenAI Responses tool call
+curl -X POST http://localhost:3000/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "x-mock-scenario: tool_call" \
+  -d '{"model":"gpt-4.1-mini","input":"查询订单 A100","tools":[{"type":"function","name":"get_order"}]}'
+
+# Anthropic parallel tool use
+curl -X POST http://localhost:3000/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-mock-scenario: parallel_tools" \
+  -d '{"model":"claude-sonnet-4-5","max_tokens":256,"messages":[{"role":"user","content":"查询订单和天气"}],"tools":[{"name":"get_order","input_schema":{"type":"object"}},{"name":"get_weather","input_schema":{"type":"object"}}]}'
+
+# Gemini structured JSON
+curl -X POST http://localhost:3000/v1beta/models/gemini-1.5-flash:generateContent \
+  -H "Content-Type: application/json" \
+  -d '{"contents":[{"role":"user","parts":[{"text":"提取商品数据"}]}],"generationConfig":{"responseMimeType":"application/json","responseSchema":{"type":"OBJECT"}}}'
+
+# 延迟流式分块
+curl -N -X POST http://localhost:3000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "x-mock-stream-chunk-ms: 100" \
+  -d '{"model":"gpt-4.1-mini","stream":true,"messages":[{"role":"user","content":"慢速流式输出"}]}'
 ```
+
+### Fixture 贡献
+
+Fixture 示例位于：
+
+```txt
+src/fixtures/openai/
+src/fixtures/anthropic/
+src/fixtures/gemini/
+```
+
+新增 fixture 时请保持离线、确定性：不要复制真实线上 provider payload，不做真实 API 调用，ID/时间戳要稳定，并为新增场景补充对应 contract 或 unit test。当前运行时响应主要由 provider service 生成，fixture 文件用于贡献示例和后续 fixture-store 扩展。
+
+### 迁移说明
+
+旧版端点会继续保留：`/models`、`/chat/completions`、`/images/generations`、`/anthropic/v1/models`、`/anthropic/v1/messages`、以及 `/gemini/v1/...` 别名仍然可用；新的 `/v1/...` 和 `/v1beta/...` provider 兼容端点会继续扩展。
 
 ## 🌐 部署
 
@@ -418,6 +523,13 @@ curl -X POST http://localhost:3000/v1/images/generations \
 
 ### 使用 OpenAI SDK 测试
 
+本地 SDK smoke tests 默认跳过，只有显式开启时才运行：
+
+```bash
+npm test
+RUN_SDK_TESTS=1 npm test -- test/sdk
+```
+
 ```javascript
 import OpenAI from 'openai';
 
@@ -462,6 +574,54 @@ const image = await client.images.generate({
 });
 
 console.log(image.data[0].url);
+```
+
+### 使用 Anthropic SDK 测试
+
+```javascript
+import Anthropic from '@anthropic-ai/sdk';
+
+const anthropic = new Anthropic({
+  baseURL: 'http://localhost:3000',
+  apiKey: 'mock-key'
+});
+
+const message = await anthropic.messages.create({
+  model: 'claude-sonnet-4-5',
+  max_tokens: 256,
+  messages: [{ role: 'user', content: '你好' }],
+  tools: [{ name: 'get_order', input_schema: { type: 'object' } }]
+});
+
+console.log(message.content);
+```
+
+### 使用 Google GenAI SDK 测试
+
+```javascript
+import { GoogleGenAI } from '@google/genai';
+
+const ai = new GoogleGenAI({
+  apiKey: 'mock-key',
+  httpOptions: {
+    baseUrl: 'http://localhost:3000',
+    apiVersion: 'v1beta'
+  }
+});
+
+const response = await ai.models.generateContent({
+  model: 'gemini-1.5-flash',
+  contents: '你好'
+});
+
+console.log(response.text);
+
+const file = await ai.files.upload({
+  file: new Blob(['mock file'], { type: 'text/plain' }),
+  config: { mimeType: 'text/plain', displayName: 'mock.txt' }
+});
+
+console.log(file.uri);
 ```
 
 ## 🤝 贡献

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,20 +11,60 @@
       "dependencies": {
         "commander": "^15.0.0",
         "cors": "^2.8.5",
-        "express": "^5.0.0"
+        "express": "^5.0.0",
+        "multer": "^2.1.1"
       },
       "bin": {
         "mock-openai-api": "dist/cli.js"
       },
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.102.0",
+        "@google/genai": "^2.8.0",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
+        "@types/multer": "^2.1.0",
         "@types/node": "^22.0.0",
+        "@types/supertest": "^7.2.0",
+        "openai": "^6.42.0",
+        "supertest": "^7.2.2",
         "ts-node": "^10.9.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.8"
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.102.0.tgz",
+      "integrity": "sha512-cThh3KcPW3lzkFyTz1cjyhJvOVw45NkLMoowO2ZJ/76CBz44ADUon+NsjEc/PypAkARs72Xu8qxTnx6PAOTQUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -40,6 +80,65 @@
         "node": ">=12"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.8.0.tgz",
+      "integrity": "sha512-pc2ayxqO5+O7AvnHBqpNHIk7PAZkHZgL31tbyx0gJZBSS9qPYiQoqwK7oYOw/ePmG6QY4EMSu+304vD5QlhXAw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -51,9 +150,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -67,6 +166,427 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -96,6 +616,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -105,6 +636,17 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/connect": {
@@ -117,6 +659,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -126,6 +675,20 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "5.0.6",
@@ -159,12 +722,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.19.20",
@@ -190,6 +770,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
@@ -210,6 +797,143 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -251,12 +975,83 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -280,6 +1075,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -320,6 +1139,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
@@ -327,6 +1169,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -350,6 +1217,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
@@ -367,6 +1241,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -392,6 +1273,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -409,6 +1300,16 @@
         }
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -416,6 +1317,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -440,6 +1362,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -475,6 +1407,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -487,11 +1426,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -500,6 +1465,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -545,6 +1520,69 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -560,6 +1598,77 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -580,6 +1689,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -587,6 +1711,36 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-intrinsic": {
@@ -626,6 +1780,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -643,6 +1825,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -682,6 +1880,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -718,6 +1930,343 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -756,6 +2305,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -783,6 +2355,87 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -790,6 +2443,46 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/object-assign": {
@@ -813,6 +2506,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -834,6 +2541,39 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openai": {
+      "version": "6.42.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
+      "integrity": "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -851,6 +2591,87 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -903,6 +2724,64 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/router": {
@@ -1062,6 +2941,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1069,6 +2983,110 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -1079,6 +3097,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -1124,6 +3149,14 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1137,6 +3170,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -1168,6 +3207,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -1184,11 +3229,228 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -37,20 +37,28 @@
     "build": "tsc",
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "cli": "ts-node src/cli.ts",
     "lint": "npx -y oxlint src/**/*.ts"
   },
   "dependencies": {
     "commander": "^15.0.0",
     "cors": "^2.8.5",
-    "express": "^5.0.0"
+    "express": "^5.0.0",
+    "multer": "^2.1.1"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.102.0",
+    "@google/genai": "^2.8.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
+    "@types/multer": "^2.1.0",
     "@types/node": "^22.0.0",
+    "@types/supertest": "^7.2.0",
+    "openai": "^6.42.0",
+    "supertest": "^7.2.2",
     "ts-node": "^10.9.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.8"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,7 @@
 import express, { Express } from "express";
 import cors from "cors";
+import { endpointSummary, formatEndpointCatalog } from "./core/http/endpointCatalog";
+import { mockLatencyMiddleware } from "./core/http/mockControls";
 import routes from "./routes";
 
 // 扩展全局对象类型
@@ -8,11 +10,20 @@ declare global {
 }
 
 const app: Express = express();
+const jsonParser = express.json({ limit: "10mb" });
 
 // Middleware
 app.use(cors());
-app.use(express.json({ limit: "10mb" }));
+app.use((req, res, next) => {
+  if (isGeminiResumableUploadChunk(req)) {
+    next();
+    return;
+  }
+
+  jsonParser(req, res, next);
+});
 app.use(express.urlencoded({ extended: true }));
+app.use(mockLatencyMiddleware());
 
 // Request logging middleware (conditional)
 app.use((req, res, next) => {
@@ -34,17 +45,7 @@ app.get("/", (req, res) => {
     message: "Mock OpenAI API Server",
     status: "running",
     timestamp: new Date().toISOString(),
-    availableEndpoints: [
-      "GET /health",
-      "GET /v1/models",
-      "POST /v1/chat/completions",
-      "POST /v1/images/generations",
-      "GET /anthropic/v1/models",
-      "POST /anthropic/v1/messages",
-      "GET /v1beta/models",
-      "POST /v1beta/models/{model}:generateContent",
-      "POST /v1beta/models/{model}:streamGenerateContent",
-    ],
+    availableEndpoints: endpointSummary(),
   });
 });
 
@@ -57,15 +58,7 @@ app.use((req, res) => {
   console.log(`❌ Method: ${req.method}`);
   console.log(`❌ Headers:`, JSON.stringify(req.headers, null, 2));
   console.log(`❌ Available routes:`);
-  console.log(`   - GET /health`);
-  console.log(`   - GET /v1/models`);
-  console.log(`   - POST /v1/chat/completions`);
-  console.log(`   - POST /v1/images/generations`);
-  console.log(`   - GET /anthropic/v1/models`);
-  console.log(`   - POST /anthropic/v1/messages`);
-  console.log(`   - GET /v1beta/models`);
-  console.log(`   - POST /v1beta/models/{model}:generateContent`);
-  console.log(`   - POST /v1beta/models/{model}:streamGenerateContent`);
+  formatEndpointCatalog().forEach((line) => console.log(line));
   
   res.status(404).json({
     error: {
@@ -75,17 +68,7 @@ app.use((req, res) => {
       method: req.method,
       path: req.path,
       originalUrl: req.originalUrl,
-      availableEndpoints: [
-        "GET /health",
-        "GET /v1/models",
-        "POST /v1/chat/completions",
-        "POST /v1/images/generations",
-        "GET /anthropic/v1/models",
-        "POST /anthropic/v1/messages",
-        "GET /v1beta/models",
-        "POST /v1beta/models/{model}:generateContent",
-        "POST /v1beta/models/{model}:streamGenerateContent",
-      ],
+      availableEndpoints: endpointSummary(),
     },
   });
 });
@@ -108,5 +91,10 @@ app.use(
     });
   }
 );
+
+function isGeminiResumableUploadChunk(req: express.Request): boolean {
+  const command = req.header("x-goog-upload-command")?.toLowerCase() || "";
+  return req.method === "POST" && req.path.startsWith("/upload/v1beta/files/") && !command.includes("start");
+}
 
 export default app;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander';
 import app from './app';
 import { version } from '../package.json'
+import { formatEndpointCatalog } from './core/http/endpointCatalog';
 import { loadModelMapping, getMappedModelName } from './config/modelMapping';
 // 扩展全局对象类型
 declare global {
@@ -42,15 +43,7 @@ app.listen(PORT, HOST, () => {
   console.log(`   • Config file: ${options.config}`);
   console.log(`   • Version: ${version}`);
   console.log(`📖 API Documentation:`);
-  console.log(`   • GET  /health - Health check`);
-  console.log(`   • GET  /v1/models - Get OpenAI model list`);
-  console.log(`   • POST /v1/chat/completions - OpenAI chat completions`);
-  console.log(`   • POST /v1/images/generations - OpenAI image generation`);
-  console.log(`   • GET  /anthropic/v1/models - Get Anthropic model list`);
-  console.log(`   • POST /anthropic/v1/messages - Anthropic message API`);
-  console.log(`   • GET  /v1beta/models - Get Gemini model list`);
-  console.log(`   • POST /v1beta/models/{model}:generateContent - Gemini content generation`);
-  console.log(`   • POST /v1beta/models/{model}:streamGenerateContent - Gemini streaming generation`);
+  formatEndpointCatalog().forEach((line) => console.log(line));
   console.log(`\n✨ Available models:`);
   console.log(`   OpenAI Compatible:`);
   console.log(`   - ${getMappedModelName('mock-gpt-thinking')}: Model supporting thought process`);
@@ -64,13 +57,25 @@ app.listen(PORT, HOST, () => {
   console.log(`   - ${getMappedModelName('gemini-1.5-flash')}: Fast and efficient model`);
   console.log(`   - ${getMappedModelName('gemini-pro')}: Versatile model for various tasks`);
   console.log(`   - ${getMappedModelName('gemini-pro-vision')}: Multimodal model for text and images`);
-  console.log(`\n🔗 Usage example:`);
-  console.log(`   curl -X POST http://localhost:${PORT}/v1/chat/completions \\`);
+  console.log(`\n🔗 Usage examples:`);
+  console.log(`   # OpenAI Responses API`);
+  console.log(`   curl -X POST http://localhost:${PORT}/v1/responses \\`);
   console.log(`     -H "Content-Type: application/json" \\`);
   console.log(`     -d '{`);
-  console.log(`       "model": "${getMappedModelName('gpt-4-mock')}",`);
-  console.log(`       "messages": [{"role": "user", "content": "Hello"}]`);
+  console.log(`       "model": "gpt-4.1-mini",`);
+  console.log(`       "input": "Hello from a local agent harness"`);
   console.log(`     }'`);
+  console.log(``);
+  console.log(`   # Anthropic Messages API`);
+  console.log(`   curl -X POST http://localhost:${PORT}/v1/messages \\`);
+  console.log(`     -H "Content-Type: application/json" \\`);
+  console.log(`     -H "anthropic-version: 2023-06-01" \\`);
+  console.log(`     -d '{"model":"claude-sonnet-4-5","max_tokens":256,"messages":[{"role":"user","content":"Hello"}]}'`);
+  console.log(``);
+  console.log(`   # Gemini GenerateContent API`);
+  console.log(`   curl -X POST http://localhost:${PORT}/v1beta/models/gemini-1.5-flash:generateContent \\`);
+  console.log(`     -H "Content-Type: application/json" \\`);
+  console.log(`     -d '{"contents":[{"role":"user","parts":[{"text":"Hello"}]}]}'`);
   console.log(`\n💡 CLI Options:`);
   console.log(`   • Use --help to see all available options`);
   console.log(`   • Use -v or --verbose to enable request logging`);

--- a/src/core/errors/errorInjector.ts
+++ b/src/core/errors/errorInjector.ts
@@ -50,5 +50,11 @@ function readQueryString(query: Record<string, unknown>, name: string): string |
     return String(value);
   }
 
+  if (Array.isArray(value)) {
+    const firstScalar = value.find((item) => typeof item === "string" || typeof item === "number");
+    if (typeof firstScalar === "string") return firstScalar;
+    if (typeof firstScalar === "number") return String(firstScalar);
+  }
+
   return undefined;
 }

--- a/src/core/errors/errorInjector.ts
+++ b/src/core/errors/errorInjector.ts
@@ -1,0 +1,54 @@
+import { ProviderName } from "../scenarioEngine";
+import {
+  buildProviderError,
+  InjectableErrorStatus,
+  isInjectableErrorStatus,
+  ProviderError,
+} from "./providerErrors";
+
+export type ErrorInjectionInput = {
+  provider: ProviderName;
+  headers: Record<string, string | string[] | undefined>;
+  query: Record<string, unknown>;
+  message?: string;
+};
+
+export function getInjectedProviderError(input: ErrorInjectionInput): ProviderError | undefined {
+  const status = getInjectedErrorStatus(input.headers, input.query);
+
+  return status ? buildProviderError(input.provider, status, input.message) : undefined;
+}
+
+export function getInjectedErrorStatus(
+  headers: Record<string, string | string[] | undefined>,
+  query: Record<string, unknown>
+): InjectableErrorStatus | undefined {
+  const value = readHeader(headers, "x-mock-error") || readQueryString(query, "mock_error");
+  const status = Number(value);
+
+  return Number.isInteger(status) && isInjectableErrorStatus(status) ? status : undefined;
+}
+
+function readHeader(
+  headers: Record<string, string | string[] | undefined>,
+  name: string
+): string | undefined {
+  const key = Object.keys(headers).find((header) => header.toLowerCase() === name.toLowerCase());
+  const value = key ? headers[key] : undefined;
+
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function readQueryString(query: Record<string, unknown>, name: string): string | undefined {
+  const value = query[name];
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return String(value);
+  }
+
+  return undefined;
+}

--- a/src/core/errors/providerErrors.ts
+++ b/src/core/errors/providerErrors.ts
@@ -1,0 +1,136 @@
+import { ProviderName } from "../scenarioEngine";
+
+export type InjectableErrorStatus = 400 | 401 | 403 | 404 | 409 | 429 | 500 | 529;
+
+export type ProviderError = {
+  status: InjectableErrorStatus;
+  body: unknown;
+};
+
+const ERROR_STATUSES = new Set<number>([400, 401, 403, 404, 409, 429, 500, 529]);
+
+const DEFAULT_MESSAGES: Record<InjectableErrorStatus, string> = {
+  400: "Invalid request.",
+  401: "Authentication failed.",
+  403: "Permission denied.",
+  404: "Resource not found.",
+  409: "Request conflicts with current resource state.",
+  429: "Rate limit exceeded.",
+  500: "Internal server error.",
+  529: "Service overloaded.",
+};
+
+const OPENAI_TYPES: Record<InjectableErrorStatus, string> = {
+  400: "invalid_request_error",
+  401: "authentication_error",
+  403: "permission_error",
+  404: "not_found_error",
+  409: "conflict_error",
+  429: "rate_limit_error",
+  500: "server_error",
+  529: "overloaded_error",
+};
+
+const OPENAI_CODES: Record<InjectableErrorStatus, string> = {
+  400: "invalid_request",
+  401: "invalid_api_key",
+  403: "permission_denied",
+  404: "not_found",
+  409: "conflict",
+  429: "rate_limit_exceeded",
+  500: "internal_error",
+  529: "overloaded",
+};
+
+const ANTHROPIC_TYPES: Record<InjectableErrorStatus, string> = {
+  400: "invalid_request_error",
+  401: "authentication_error",
+  403: "permission_error",
+  404: "not_found_error",
+  409: "conflict_error",
+  429: "rate_limit_error",
+  500: "api_error",
+  529: "overloaded_error",
+};
+
+const GEMINI_STATUSES: Record<InjectableErrorStatus, string> = {
+  400: "INVALID_ARGUMENT",
+  401: "UNAUTHENTICATED",
+  403: "PERMISSION_DENIED",
+  404: "NOT_FOUND",
+  409: "ABORTED",
+  429: "RESOURCE_EXHAUSTED",
+  500: "INTERNAL",
+  529: "UNAVAILABLE",
+};
+
+export function isInjectableErrorStatus(status: number): status is InjectableErrorStatus {
+  return ERROR_STATUSES.has(status);
+}
+
+export function buildProviderError(
+  provider: ProviderName,
+  status: InjectableErrorStatus,
+  message = DEFAULT_MESSAGES[status],
+  param?: string
+): ProviderError {
+  if (provider === "openai") {
+    return buildOpenAIError(status, message, param);
+  }
+
+  if (provider === "anthropic") {
+    return buildAnthropicError(status, message);
+  }
+
+  return buildGeminiError(status, message);
+}
+
+export function buildOpenAIError(
+  status: InjectableErrorStatus,
+  message = DEFAULT_MESSAGES[status],
+  param?: string
+): ProviderError {
+  return {
+    status,
+    body: {
+      error: {
+        message,
+        type: OPENAI_TYPES[status],
+        param: param || null,
+        code: OPENAI_CODES[status],
+      },
+    },
+  };
+}
+
+export function buildAnthropicError(
+  status: InjectableErrorStatus,
+  message = DEFAULT_MESSAGES[status]
+): ProviderError {
+  return {
+    status,
+    body: {
+      type: "error",
+      error: {
+        type: ANTHROPIC_TYPES[status],
+        message,
+      },
+    },
+  };
+}
+
+export function buildGeminiError(
+  status: InjectableErrorStatus,
+  message = DEFAULT_MESSAGES[status]
+): ProviderError {
+  return {
+    status,
+    body: {
+      error: {
+        code: status,
+        message,
+        status: GEMINI_STATUSES[status],
+      },
+    },
+  };
+}

--- a/src/core/fixtures/fixtureMatcher.ts
+++ b/src/core/fixtures/fixtureMatcher.ts
@@ -1,0 +1,19 @@
+import { ProviderName, ScenarioName } from "../scenarioEngine";
+import { FixtureRecord, FixtureStore } from "./fixtureStore";
+
+export type FixtureMatchInput = {
+  provider: ProviderName;
+  endpoint: string;
+  scenario: ScenarioName;
+  name?: string;
+};
+
+export function matchFixture<T>(
+  store: FixtureStore,
+  input: FixtureMatchInput
+): FixtureRecord<T> | undefined {
+  return (
+    store.get<T>(input.provider, input.endpoint, input.scenario, input.name) ||
+    store.get<T>(input.provider, input.endpoint, "simple_text", input.name)
+  );
+}

--- a/src/core/fixtures/fixtureStore.ts
+++ b/src/core/fixtures/fixtureStore.ts
@@ -1,0 +1,47 @@
+import { ProviderName, ScenarioName } from "../scenarioEngine";
+
+export type FixtureRecord<T = unknown> = {
+  provider: ProviderName;
+  endpoint: string;
+  scenario: ScenarioName;
+  name?: string;
+  data: T;
+};
+
+export class FixtureStore {
+  private readonly fixtures = new Map<string, FixtureRecord>();
+
+  register<T>(fixture: FixtureRecord<T>): FixtureRecord<T> {
+    this.fixtures.set(fixtureKey(fixture), fixture as FixtureRecord);
+    return fixture;
+  }
+
+  get<T>(
+    provider: ProviderName,
+    endpoint: string,
+    scenario: ScenarioName,
+    name = "default"
+  ): FixtureRecord<T> | undefined {
+    return this.fixtures.get(fixtureKey({ provider, endpoint, scenario, name })) as
+      | FixtureRecord<T>
+      | undefined;
+  }
+
+  list(provider?: ProviderName): FixtureRecord[] {
+    const records = Array.from(this.fixtures.values());
+    return provider ? records.filter((record) => record.provider === provider) : records;
+  }
+
+  clear(): void {
+    this.fixtures.clear();
+  }
+}
+
+export function fixtureKey(input: {
+  provider: ProviderName;
+  endpoint: string;
+  scenario: ScenarioName;
+  name?: string;
+}): string {
+  return [input.provider, input.endpoint, input.scenario, input.name || "default"].join(":");
+}

--- a/src/core/http/endpointCatalog.ts
+++ b/src/core/http/endpointCatalog.ts
@@ -1,0 +1,89 @@
+export type EndpointCatalogItem = {
+  method: string;
+  path: string;
+  description: string;
+};
+
+export type EndpointCatalogGroup = {
+  title: string;
+  items: EndpointCatalogItem[];
+};
+
+export const endpointCatalog: EndpointCatalogGroup[] = [
+  {
+    title: "Common",
+    items: [
+      { method: "GET", path: "/health", description: "Health check" },
+      { method: "GET", path: "/", description: "Server metadata and endpoint summary" },
+    ],
+  },
+  {
+    title: "OpenAI compatible",
+    items: [
+      { method: "GET", path: "/v1/models", description: "Model list by default" },
+      { method: "POST", path: "/v1/responses", description: "Responses API create/stream/tool calls" },
+      { method: "GET", path: "/v1/responses/{response_id}", description: "Retrieve a stored response" },
+      { method: "POST", path: "/v1/responses/{response_id}/cancel", description: "Cancel queued responses" },
+      { method: "GET", path: "/v1/responses/{response_id}/input_items", description: "List response input items" },
+      { method: "POST", path: "/v1/responses/input_tokens", description: "Count response input tokens" },
+      { method: "POST", path: "/v1/responses/compact", description: "Create a compacted mock response" },
+      { method: "POST", path: "/v1/chat/completions", description: "Chat Completions create/stream/tool calls" },
+      { method: "GET", path: "/v1/chat/completions/{completion_id}", description: "Retrieve stored chat completion" },
+      { method: "POST", path: "/v1/embeddings", description: "Deterministic embeddings" },
+      { method: "POST", path: "/v1/images/generations", description: "Image generation" },
+      { method: "POST", path: "/v1/images/edits", description: "Image edits" },
+      { method: "POST", path: "/v1/images/variations", description: "Image variations" },
+      { method: "POST", path: "/v1/files", description: "Upload mock files" },
+      { method: "GET", path: "/v1/files", description: "List mock files" },
+    ],
+  },
+  {
+    title: "Anthropic compatible",
+    items: [
+      { method: "GET", path: "/v1/models", description: "Anthropic list with anthropic-version or x-provider" },
+      { method: "GET", path: "/anthropic/v1/models", description: "Legacy Anthropic model list alias" },
+      { method: "POST", path: "/v1/messages", description: "Messages create/stream/tool use/thinking" },
+      { method: "POST", path: "/v1/messages/count_tokens", description: "Message token counting" },
+      { method: "POST", path: "/v1/files", description: "Anthropic-shaped files with provider header" },
+      { method: "POST", path: "/anthropic/v1/messages", description: "Legacy Anthropic messages alias" },
+    ],
+  },
+  {
+    title: "Gemini compatible",
+    items: [
+      { method: "GET", path: "/v1/models?provider=gemini", description: "Gemini model list through provider dispatch" },
+      { method: "GET", path: "/v1beta/models", description: "Gemini model list" },
+      { method: "POST", path: "/v1beta/models/{model}:generateContent", description: "GenerateContent" },
+      { method: "POST", path: "/v1beta/models/{model}:streamGenerateContent", description: "SSE GenerateContent stream" },
+      { method: "POST", path: "/v1beta/models/{model}:countTokens", description: "Token counting" },
+      { method: "POST", path: "/upload/v1beta/files", description: "File upload, including SDK resumable upload" },
+      { method: "GET", path: "/v1beta/files", description: "List Gemini files" },
+      { method: "POST", path: "/v1beta/cachedContents", description: "Create cached content" },
+      { method: "GET", path: "/v1beta/cachedContents", description: "List cached contents" },
+    ],
+  },
+  {
+    title: "Legacy aliases",
+    items: [
+      { method: "GET", path: "/models", description: "OpenAI model list alias" },
+      { method: "POST", path: "/chat/completions", description: "OpenAI chat alias" },
+      { method: "POST", path: "/images/generations", description: "OpenAI image alias" },
+      { method: "GET", path: "/gemini/v1/models", description: "Gemini model list alias" },
+      { method: "POST", path: "/gemini/v1/models/{model}/generateContent", description: "Gemini generate alias" },
+      { method: "POST", path: "/gemini/v1/models/{model}/streamGenerateContent", description: "Gemini stream alias" },
+    ],
+  },
+];
+
+export function endpointSummary(): string[] {
+  return endpointCatalog.flatMap((group) =>
+    group.items.map((item) => `${item.method} ${item.path}`)
+  );
+}
+
+export function formatEndpointCatalog(): string[] {
+  return endpointCatalog.flatMap((group) => [
+    `   ${group.title}:`,
+    ...group.items.map((item) => `   • ${item.method.padEnd(4)} ${item.path} - ${item.description}`),
+  ]);
+}

--- a/src/core/http/mockControls.ts
+++ b/src/core/http/mockControls.ts
@@ -1,0 +1,68 @@
+import { NextFunction, Request, RequestHandler, Response } from "express";
+
+const MAX_DELAY_MS = 30_000;
+
+export function mockLatencyMiddleware(): RequestHandler {
+  return async (req: Request, _res: Response, next: NextFunction) => {
+    const latencyMs = readMockControlNumber(req, "x-mock-latency-ms", "mock_latency_ms");
+
+    if (latencyMs > 0) {
+      await delay(latencyMs);
+    }
+
+    next();
+  };
+}
+
+export function readMockStreamChunkDelay(req: Request): number {
+  return readMockControlNumber(req, "x-mock-stream-chunk-ms", "mock_stream_chunk_ms");
+}
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, clampDelay(ms));
+  });
+}
+
+function readMockControlNumber(req: Request, headerName: string, queryName: string): number {
+  const value =
+    req.header(headerName) ||
+    readQueryValue(req.query[queryName]) ||
+    readBodyValue(req.body, queryName);
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) && parsed > 0 ? clampDelay(parsed) : 0;
+}
+
+function readQueryValue(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function readBodyValue(body: unknown, key: string): string | undefined {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return undefined;
+  }
+
+  const value = (body as Record<string, unknown>)[key];
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function clampDelay(ms: number): number {
+  return Math.max(0, Math.min(Math.floor(ms), MAX_DELAY_MS));
+}

--- a/src/core/scenarioEngine.ts
+++ b/src/core/scenarioEngine.ts
@@ -1,0 +1,424 @@
+export type ProviderName = "openai" | "anthropic" | "gemini";
+
+export type ScenarioName =
+  | "simple_text"
+  | "stream_text"
+  | "tool_call"
+  | "parallel_tools"
+  | "tool_result"
+  | "structured_json"
+  | "vision"
+  | "multimodal_audio"
+  | "multimodal_video"
+  | "file_reference"
+  | "reasoning"
+  | "thinking"
+  | "background"
+  | "pause_turn"
+  | "cancelled"
+  | "failed"
+  | "refusal"
+  | "safety_block"
+  | "rate_limit"
+  | "invalid_request"
+  | "invalid_tool_args";
+
+export type ScenarioInput = {
+  provider: ProviderName;
+  endpoint: string;
+  method: string;
+  headers: Record<string, string | string[] | undefined>;
+  query: Record<string, unknown>;
+  body: unknown;
+  model?: string;
+};
+
+export type ScenarioSelection = {
+  provider: ProviderName;
+  scenario: ScenarioName;
+  seed: string;
+  latencyMs: number;
+  streamChunkMs: number;
+  forcedError?: number;
+};
+
+const SCENARIOS = new Set<ScenarioName>([
+  "simple_text",
+  "stream_text",
+  "tool_call",
+  "parallel_tools",
+  "tool_result",
+  "structured_json",
+  "vision",
+  "multimodal_audio",
+  "multimodal_video",
+  "file_reference",
+  "reasoning",
+  "thinking",
+  "background",
+  "pause_turn",
+  "cancelled",
+  "failed",
+  "refusal",
+  "safety_block",
+  "rate_limit",
+  "invalid_request",
+  "invalid_tool_args",
+]);
+
+const ERROR_SCENARIOS: Record<number, ScenarioName> = {
+  400: "invalid_request",
+  409: "failed",
+  429: "rate_limit",
+  500: "failed",
+  529: "rate_limit",
+};
+
+export function selectScenario(input: ScenarioInput): ScenarioSelection {
+  const forcedError = readNumberControl(input, "x-mock-error", "mock_error");
+  const seed = readStringControl(input, "x-mock-seed", "mock_seed") || "default";
+  const latencyMs = readNumberControl(input, "x-mock-latency-ms", "mock_latency_ms") || 0;
+  const streamChunkMs = readNumberControl(input, "x-mock-stream-chunk-ms", "mock_stream_chunk_ms") || 0;
+
+  if (forcedError !== undefined) {
+    return {
+      provider: input.provider,
+      scenario: ERROR_SCENARIOS[forcedError] || "failed",
+      seed,
+      latencyMs,
+      streamChunkMs,
+      forcedError,
+    };
+  }
+
+  const explicitScenario = readScenarioControl(input);
+  if (explicitScenario) {
+    return {
+      provider: input.provider,
+      scenario: explicitScenario,
+      seed,
+      latencyMs,
+      streamChunkMs,
+    };
+  }
+
+  return {
+    provider: input.provider,
+    scenario: inferScenario(input),
+    seed,
+    latencyMs,
+    streamChunkMs,
+  };
+}
+
+export function isScenarioName(value: unknown): value is ScenarioName {
+  return typeof value === "string" && SCENARIOS.has(value as ScenarioName);
+}
+
+function inferScenario(input: ScenarioInput): ScenarioName {
+  const body = input.body;
+  const model = (input.model || readBodyString(body, "model") || "").toLowerCase();
+
+  if (readBodyBoolean(body, "stream")) {
+    return "stream_text";
+  }
+
+  if (containsToolResult(body)) {
+    return "tool_result";
+  }
+
+  if (containsParallelTools(body)) {
+    return "parallel_tools";
+  }
+
+  if (containsToolDeclaration(body)) {
+    return "tool_call";
+  }
+
+  if (containsStructuredOutputRequest(body)) {
+    return "structured_json";
+  }
+
+  const multimodal = inferMultimodalScenario(body);
+  if (multimodal) {
+    return multimodal;
+  }
+
+  if (
+    readBodyBoolean(body, "background") ||
+    readBooleanControl(input, "x-mock-background", "mock_background")
+  ) {
+    return "background";
+  }
+
+  if (model.includes("thinking")) {
+    return "thinking";
+  }
+
+  if (model.includes("reasoning")) {
+    return "reasoning";
+  }
+
+  if (model.includes("json")) {
+    return "structured_json";
+  }
+
+  if (model.includes("refusal")) {
+    return "refusal";
+  }
+
+  if (model.includes("safety")) {
+    return "safety_block";
+  }
+
+  return "simple_text";
+}
+
+function readScenarioControl(input: ScenarioInput): ScenarioName | undefined {
+  const value =
+    readHeader(input.headers, "x-mock-scenario") ||
+    readQueryString(input.query, "mock_scenario") ||
+    readBodyString(input.body, "mock_scenario");
+
+  return isScenarioName(value) ? value : undefined;
+}
+
+function readStringControl(
+  input: ScenarioInput,
+  headerName: string,
+  queryName: string
+): string | undefined {
+  return (
+    readHeader(input.headers, headerName) ||
+    readQueryString(input.query, queryName) ||
+    readBodyString(input.body, queryName)
+  );
+}
+
+function readNumberControl(
+  input: ScenarioInput,
+  headerName: string,
+  queryName: string
+): number | undefined {
+  const value =
+    readHeader(input.headers, headerName) ||
+    readQueryString(input.query, queryName) ||
+    readBodyString(input.body, queryName);
+  const numberValue = Number(value);
+
+  return Number.isFinite(numberValue) && numberValue >= 0 ? numberValue : undefined;
+}
+
+function readBooleanControl(input: ScenarioInput, headerName: string, queryName: string): boolean {
+  const value =
+    readHeader(input.headers, headerName) ||
+    readQueryString(input.query, queryName) ||
+    readBodyString(input.body, queryName);
+
+  return parseBoolean(value);
+}
+
+function readHeader(
+  headers: Record<string, string | string[] | undefined>,
+  name: string
+): string | undefined {
+  const key = Object.keys(headers).find((header) => header.toLowerCase() === name.toLowerCase());
+  const value = key ? headers[key] : undefined;
+
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function readQueryString(query: Record<string, unknown>, name: string): string | undefined {
+  const value = query[name];
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function readBodyString(body: unknown, name: string): string | undefined {
+  if (!isRecord(body)) {
+    return undefined;
+  }
+
+  const value = body[name];
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function readBodyBoolean(body: unknown, name: string): boolean {
+  if (!isRecord(body)) {
+    return false;
+  }
+
+  return parseBoolean(body[name]);
+}
+
+function parseBoolean(value: unknown): boolean {
+  return value === true || value === "true" || value === "1";
+}
+
+function containsToolResult(value: unknown): boolean {
+  return walk(value, (entry) => {
+    if (!isRecord(entry)) {
+      return false;
+    }
+
+    return (
+      entry.type === "function_call_output" ||
+      entry.type === "computer_call_output" ||
+      entry.type === "tool_result" ||
+      isRecord(entry.functionResponse)
+    );
+  });
+}
+
+function containsParallelTools(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.parallel_tool_calls === true || value.parallelToolCalls === true) {
+    return containsToolDeclaration(value);
+  }
+
+  if (Array.isArray(value.tools) && value.tools.length > 1) {
+    return true;
+  }
+
+  return walk(value.tools, (entry) => {
+    if (!isRecord(entry) || !Array.isArray(entry.functionDeclarations)) {
+      return false;
+    }
+
+    return entry.functionDeclarations.length > 1;
+  });
+}
+
+function containsToolDeclaration(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (Array.isArray(value.tools) && value.tools.length > 0) {
+    return true;
+  }
+
+  if (Array.isArray(value.functions) && value.functions.length > 0) {
+    return true;
+  }
+
+  return walk(value, (entry) => {
+    return isRecord(entry) && Array.isArray(entry.functionDeclarations) && entry.functionDeclarations.length > 0;
+  });
+}
+
+function containsStructuredOutputRequest(value: unknown): boolean {
+  return walk(value, (entry) => {
+    if (!isRecord(entry)) {
+      return false;
+    }
+
+    if (entry.type === "json_schema" || entry.type === "json_object") {
+      return true;
+    }
+
+    if (entry.responseMimeType === "application/json" || entry.responseMimeType === "text/x.enum") {
+      return true;
+    }
+
+    return Boolean(entry.responseSchema || entry.json_schema);
+  });
+}
+
+function inferMultimodalScenario(value: unknown): ScenarioName | undefined {
+  let scenario: ScenarioName | undefined;
+
+  walk(value, (entry) => {
+    if (!isRecord(entry)) {
+      return false;
+    }
+
+    const mimeType =
+      readRecordString(entry, "mimeType") ||
+      readRecordString(entry, "media_type") ||
+      readRecordString(entry, "mime_type");
+
+    if (
+      entry.type === "input_audio" ||
+      entry.input_audio ||
+      (mimeType && mimeType.startsWith("audio/"))
+    ) {
+      scenario = "multimodal_audio";
+      return true;
+    }
+
+    if (entry.type === "input_video" || (mimeType && mimeType.startsWith("video/"))) {
+      scenario = "multimodal_video";
+      return true;
+    }
+
+    if (
+      entry.type === "input_image" ||
+      entry.type === "image" ||
+      entry.image_url ||
+      (mimeType && mimeType.startsWith("image/"))
+    ) {
+      scenario = "vision";
+      return true;
+    }
+
+    if (
+      entry.type === "input_file" ||
+      entry.type === "document" ||
+      entry.file_id ||
+      entry.fileData ||
+      entry.file_data
+    ) {
+      scenario = "file_reference";
+      return true;
+    }
+
+    return false;
+  });
+
+  return scenario;
+}
+
+function readRecordString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function walk(value: unknown, predicate: (entry: unknown) => boolean): boolean {
+  if (predicate(value)) {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((entry) => walk(entry, predicate));
+  }
+
+  if (isRecord(value)) {
+    return Object.values(value).some((entry) => walk(entry, predicate));
+  }
+
+  return false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/core/scenarioEngine.ts
+++ b/src/core/scenarioEngine.ts
@@ -74,11 +74,17 @@ const ERROR_SCENARIOS: Record<number, ScenarioName> = {
   529: "rate_limit",
 };
 
+const MAX_MOCK_DELAY_MS = 30_000;
+
+function clampDelay(value: number): number {
+  return Math.min(value, MAX_MOCK_DELAY_MS);
+}
+
 export function selectScenario(input: ScenarioInput): ScenarioSelection {
   const forcedError = readNumberControl(input, "x-mock-error", "mock_error");
   const seed = readStringControl(input, "x-mock-seed", "mock_seed") || "default";
-  const latencyMs = readNumberControl(input, "x-mock-latency-ms", "mock_latency_ms") || 0;
-  const streamChunkMs = readNumberControl(input, "x-mock-stream-chunk-ms", "mock_stream_chunk_ms") || 0;
+  const latencyMs = clampDelay(readNumberControl(input, "x-mock-latency-ms", "mock_latency_ms") || 0);
+  const streamChunkMs = clampDelay(readNumberControl(input, "x-mock-stream-chunk-ms", "mock_stream_chunk_ms") || 0);
 
   if (forcedError !== undefined) {
     return {
@@ -118,10 +124,7 @@ export function isScenarioName(value: unknown): value is ScenarioName {
 function inferScenario(input: ScenarioInput): ScenarioName {
   const body = input.body;
   const model = (input.model || readBodyString(body, "model") || "").toLowerCase();
-
-  if (readBodyBoolean(body, "stream")) {
-    return "stream_text";
-  }
+  const isStreaming = readBodyBoolean(body, "stream");
 
   if (containsToolResult(body)) {
     return "tool_result";
@@ -137,6 +140,10 @@ function inferScenario(input: ScenarioInput): ScenarioName {
 
   if (containsStructuredOutputRequest(body)) {
     return "structured_json";
+  }
+
+  if (isStreaming) {
+    return "stream_text";
   }
 
   const multimodal = inferMultimodalScenario(body);

--- a/src/core/sse/anthropicSse.ts
+++ b/src/core/sse/anthropicSse.ts
@@ -1,0 +1,18 @@
+export const ANTHROPIC_SSE_HEADERS = {
+  "Content-Type": "text/event-stream; charset=utf-8",
+  "Cache-Control": "no-cache, no-transform",
+  Connection: "keep-alive",
+  "X-Accel-Buffering": "no",
+};
+
+export function anthropicEvent(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export function anthropicMessageStop(): string {
+  return anthropicEvent("message_stop", { type: "message_stop" });
+}
+
+export function encodeAnthropicSse(messages: Array<{ event: string; data: unknown }>): string {
+  return messages.map((message) => anthropicEvent(message.event, message.data)).join("");
+}

--- a/src/core/sse/geminiSse.ts
+++ b/src/core/sse/geminiSse.ts
@@ -1,0 +1,20 @@
+export const GEMINI_SSE_HEADERS = {
+  "Content-Type": "text/event-stream; charset=utf-8",
+  "Cache-Control": "no-cache, no-transform",
+  Connection: "keep-alive",
+  "X-Accel-Buffering": "no",
+};
+
+export function geminiData(data: unknown): string {
+  return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+export function geminiDone(): string {
+  return "data: [DONE]\n\n";
+}
+
+export function encodeGeminiSse(messages: unknown[], includeDone = true): string {
+  const encoded = messages.map((message) => geminiData(message)).join("");
+
+  return includeDone ? `${encoded}${geminiDone()}` : encoded;
+}

--- a/src/core/sse/openaiSse.ts
+++ b/src/core/sse/openaiSse.ts
@@ -1,0 +1,31 @@
+export const OPENAI_SSE_HEADERS = {
+  "Content-Type": "text/event-stream; charset=utf-8",
+  "Cache-Control": "no-cache, no-transform",
+  Connection: "keep-alive",
+  "X-Accel-Buffering": "no",
+};
+
+export type OpenAISseMessage = {
+  event?: string;
+  data: unknown;
+};
+
+export function openAIEvent(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export function openAIData(data: unknown): string {
+  return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+export function openAIDone(): string {
+  return "data: [DONE]\n\n";
+}
+
+export function encodeOpenAISse(messages: OpenAISseMessage[], includeDone = true): string {
+  const encoded = messages
+    .map((message) => (message.event ? openAIEvent(message.event, message.data) : openAIData(message.data)))
+    .join("");
+
+  return includeDone ? `${encoded}${openAIDone()}` : encoded;
+}

--- a/src/core/sse/streamWriter.ts
+++ b/src/core/sse/streamWriter.ts
@@ -1,0 +1,39 @@
+import { Response } from "express";
+import { delay } from "../http/mockControls";
+
+export async function sendEncodedSse(
+  res: Response,
+  headers: Record<string, string>,
+  encodedSse: string,
+  chunkDelayMs = 0
+): Promise<void> {
+  Object.entries(headers).forEach(([header, value]) => {
+    res.setHeader(header, value);
+  });
+
+  res.flushHeaders?.();
+
+  if (chunkDelayMs <= 0) {
+    res.write(encodedSse);
+    res.end();
+    return;
+  }
+
+  const frames = splitSseFrames(encodedSse);
+  for (const [index, frame] of frames.entries()) {
+    res.write(frame);
+    if (index < frames.length - 1) {
+      await delay(chunkDelayMs);
+    }
+  }
+
+  res.end();
+}
+
+export function splitSseFrames(encodedSse: string): string[] {
+  const frames = encodedSse.match(/[\s\S]*?\n\n/g) || [];
+  const consumedLength = frames.reduce((length, frame) => length + frame.length, 0);
+  const remainder = encodedSse.slice(consumedLength);
+
+  return remainder ? [...frames, remainder] : frames;
+}

--- a/src/core/state/idFactory.ts
+++ b/src/core/state/idFactory.ts
@@ -1,0 +1,61 @@
+export type IdKind =
+  | "response"
+  | "chatCompletion"
+  | "message"
+  | "toolUse"
+  | "call"
+  | "functionCall"
+  | "file"
+  | "cachedContent"
+  | "gemini";
+
+export const ID_PREFIXES: Record<IdKind, string> = {
+  response: "resp_mock",
+  chatCompletion: "chatcmpl_mock",
+  message: "msg_mock",
+  toolUse: "toolu_mock",
+  call: "call_mock",
+  functionCall: "fc_mock",
+  file: "file_mock",
+  cachedContent: "cached_mock",
+  gemini: "gemini_mock",
+};
+
+const processCounters = new Map<string, number>();
+
+export class IdFactory {
+  private readonly counters = new Map<string, number>();
+
+  constructor(private readonly seed?: string) {}
+
+  next(kind: IdKind, path: string = kind): string {
+    const prefix = ID_PREFIXES[kind];
+    const key = `${kind}:${path}`;
+    const counter = this.nextCounter(key);
+    const seedPart = this.seed ? `${sanitizeSeed(this.seed)}_` : "";
+
+    return `${prefix}_${seedPart}${counter.toString().padStart(4, "0")}`;
+  }
+
+  reset(): void {
+    this.counters.clear();
+  }
+
+  private nextCounter(key: string): number {
+    if (this.seed) {
+      const nextValue = (this.counters.get(key) || 0) + 1;
+      this.counters.set(key, nextValue);
+      return nextValue;
+    }
+
+    const processKey = `process:${key}`;
+    const nextValue = (processCounters.get(processKey) || 0) + 1;
+    processCounters.set(processKey, nextValue);
+    return nextValue;
+  }
+}
+
+function sanitizeSeed(seed: string): string {
+  const sanitized = seed.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  return sanitized.slice(0, 24) || "seed";
+}

--- a/src/core/state/memoryStore.ts
+++ b/src/core/state/memoryStore.ts
@@ -1,0 +1,92 @@
+export type MemoryCollectionName =
+  | "responses"
+  | "chatCompletions"
+  | "files"
+  | "cachedContents"
+  | "backgroundJobs";
+
+export type MockStateRecord = {
+  id: string;
+  provider?: string;
+  createdAt?: string;
+  [key: string]: unknown;
+};
+
+export type MockResponseRecord = MockStateRecord;
+export type MockChatCompletionRecord = MockStateRecord;
+export type MockFileRecord = MockStateRecord;
+export type MockCachedContentRecord = MockStateRecord;
+export type MockBackgroundJobRecord = MockStateRecord;
+
+export type StoreFilter<T extends MockStateRecord> = Partial<T> | ((record: T) => boolean);
+
+export class MemoryStateStore {
+  readonly responses = new Map<string, MockResponseRecord>();
+  readonly chatCompletions = new Map<string, MockChatCompletionRecord>();
+  readonly files = new Map<string, MockFileRecord>();
+  readonly cachedContents = new Map<string, MockCachedContentRecord>();
+  readonly backgroundJobs = new Map<string, MockBackgroundJobRecord>();
+
+  create<T extends MockStateRecord>(collection: MemoryCollectionName, record: T): T {
+    this.collection<T>(collection).set(record.id, record);
+    return record;
+  }
+
+  get<T extends MockStateRecord>(collection: MemoryCollectionName, id: string): T | undefined {
+    return this.collection<T>(collection).get(id);
+  }
+
+  update<T extends MockStateRecord>(
+    collection: MemoryCollectionName,
+    id: string,
+    patch: Partial<T>
+  ): T | undefined {
+    const existing = this.get<T>(collection, id);
+    if (!existing) {
+      return undefined;
+    }
+
+    const updated = { ...existing, ...patch } as T;
+    this.collection<T>(collection).set(id, updated);
+    return updated;
+  }
+
+  delete(collection: MemoryCollectionName, id: string): boolean {
+    return this.collection(collection).delete(id);
+  }
+
+  list<T extends MockStateRecord>(collection: MemoryCollectionName, filter?: StoreFilter<T>): T[] {
+    const records = Array.from(this.collection<T>(collection).values());
+
+    if (!filter) {
+      return records;
+    }
+
+    if (typeof filter === "function") {
+      return records.filter(filter);
+    }
+
+    return records.filter((record) =>
+      Object.entries(filter).every(([key, value]) => record[key] === value)
+    );
+  }
+
+  clear(collection?: MemoryCollectionName): void {
+    if (collection) {
+      this.collection(collection).clear();
+      return;
+    }
+
+    this.responses.clear();
+    this.chatCompletions.clear();
+    this.files.clear();
+    this.cachedContents.clear();
+    this.backgroundJobs.clear();
+  }
+
+  private collection<T extends MockStateRecord>(
+    collection: MemoryCollectionName
+  ): Map<string, T> {
+    return this[collection] as Map<string, T>;
+  }
+}

--- a/src/core/state/memoryStore.ts
+++ b/src/core/state/memoryStore.ts
@@ -46,7 +46,8 @@ export class MemoryStateStore {
       return undefined;
     }
 
-    const updated = { ...existing, ...patch } as T;
+    const { id: _ignoredId, ...rest } = patch as Partial<T> & { id?: string };
+    const updated = { ...existing, ...rest, id } as T;
     this.collection<T>(collection).set(id, updated);
     return updated;
   }

--- a/src/core/usage/tokenEstimator.ts
+++ b/src/core/usage/tokenEstimator.ts
@@ -1,0 +1,33 @@
+export function estimateTokens(input: unknown): number {
+  const text = collectText(input).join(" ").trim();
+
+  if (!text) {
+    return 0;
+  }
+
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+export function collectText(input: unknown): string[] {
+  if (typeof input === "string") {
+    return [input];
+  }
+
+  if (typeof input === "number" || typeof input === "boolean") {
+    return [String(input)];
+  }
+
+  if (Array.isArray(input)) {
+    return input.flatMap((item) => collectText(item));
+  }
+
+  if (isRecord(input)) {
+    return Object.values(input).flatMap((value) => collectText(value));
+  }
+
+  return [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/core/usage/usageBuilder.ts
+++ b/src/core/usage/usageBuilder.ts
@@ -34,13 +34,15 @@ export function buildOpenAIResponsesUsage(
 ): OpenAIResponsesUsage {
   const inputTokens = estimateTokens(input);
   const outputTokens = estimateTokens(output);
+  const safeReasoningTokens = Math.max(0, reasoningTokens);
+  const safeCachedTokens = Math.max(0, cachedTokens);
 
   return {
     input_tokens: inputTokens,
-    input_tokens_details: { cached_tokens: cachedTokens },
+    input_tokens_details: { cached_tokens: safeCachedTokens },
     output_tokens: outputTokens,
-    output_tokens_details: { reasoning_tokens: reasoningTokens },
-    total_tokens: inputTokens + outputTokens + reasoningTokens,
+    output_tokens_details: { reasoning_tokens: safeReasoningTokens },
+    total_tokens: inputTokens + outputTokens,
   };
 }
 
@@ -51,14 +53,15 @@ export function buildOpenAIChatUsage(
 ): OpenAIChatUsage {
   const promptTokens = estimateTokens(input);
   const completionTokens = estimateTokens(output);
+  const safeReasoningTokens = Math.max(0, reasoningTokens);
   const usage: OpenAIChatUsage = {
     prompt_tokens: promptTokens,
     completion_tokens: completionTokens,
-    total_tokens: promptTokens + completionTokens + reasoningTokens,
+    total_tokens: promptTokens + completionTokens,
   };
 
-  if (reasoningTokens > 0) {
-    usage.completion_tokens_details = { reasoning_tokens: reasoningTokens };
+  if (safeReasoningTokens > 0) {
+    usage.completion_tokens_details = { reasoning_tokens: safeReasoningTokens };
   }
 
   return usage;

--- a/src/core/usage/usageBuilder.ts
+++ b/src/core/usage/usageBuilder.ts
@@ -1,0 +1,83 @@
+import { estimateTokens } from "./tokenEstimator";
+
+export type OpenAIResponsesUsage = {
+  input_tokens: number;
+  input_tokens_details: { cached_tokens: number };
+  output_tokens: number;
+  output_tokens_details: { reasoning_tokens: number };
+  total_tokens: number;
+};
+
+export type OpenAIChatUsage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  completion_tokens_details?: { reasoning_tokens: number };
+};
+
+export type AnthropicUsage = {
+  input_tokens: number;
+  output_tokens: number;
+};
+
+export type GeminiUsageMetadata = {
+  promptTokenCount: number;
+  candidatesTokenCount: number;
+  totalTokenCount: number;
+};
+
+export function buildOpenAIResponsesUsage(
+  input: unknown,
+  output: unknown,
+  reasoningTokens = 0,
+  cachedTokens = 0
+): OpenAIResponsesUsage {
+  const inputTokens = estimateTokens(input);
+  const outputTokens = estimateTokens(output);
+
+  return {
+    input_tokens: inputTokens,
+    input_tokens_details: { cached_tokens: cachedTokens },
+    output_tokens: outputTokens,
+    output_tokens_details: { reasoning_tokens: reasoningTokens },
+    total_tokens: inputTokens + outputTokens + reasoningTokens,
+  };
+}
+
+export function buildOpenAIChatUsage(
+  input: unknown,
+  output: unknown,
+  reasoningTokens = 0
+): OpenAIChatUsage {
+  const promptTokens = estimateTokens(input);
+  const completionTokens = estimateTokens(output);
+  const usage: OpenAIChatUsage = {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: promptTokens + completionTokens + reasoningTokens,
+  };
+
+  if (reasoningTokens > 0) {
+    usage.completion_tokens_details = { reasoning_tokens: reasoningTokens };
+  }
+
+  return usage;
+}
+
+export function buildAnthropicUsage(input: unknown, output: unknown): AnthropicUsage {
+  return {
+    input_tokens: estimateTokens(input),
+    output_tokens: estimateTokens(output),
+  };
+}
+
+export function buildGeminiUsage(input: unknown, output: unknown): GeminiUsageMetadata {
+  const promptTokenCount = estimateTokens(input);
+  const candidatesTokenCount = estimateTokens(output);
+
+  return {
+    promptTokenCount,
+    candidatesTokenCount,
+    totalTokenCount: promptTokenCount + candidatesTokenCount,
+  };
+}

--- a/src/core/validation/anthropicSchemas.ts
+++ b/src/core/validation/anthropicSchemas.ts
@@ -1,0 +1,142 @@
+export type ValidationIssue = {
+  message: string;
+  param?: string | null;
+};
+
+export type ValidationResult = { ok: true } | { ok: false; issue: ValidationIssue };
+
+const MESSAGE_ROLES = new Set(["user", "assistant"]);
+const CONTENT_BLOCK_TYPES = new Set([
+  "text",
+  "image",
+  "document",
+  "tool_result",
+  "tool_use",
+  "thinking",
+  "redacted_thinking",
+]);
+const THINKING_TYPES = new Set(["enabled", "adaptive", "disabled"]);
+
+export function validateAnthropicMessageRequest(request: unknown): ValidationResult {
+  if (!isRecord(request) || !request.model || !request.messages || !request.max_tokens) {
+    return invalid("Missing required fields: model, messages, or max_tokens");
+  }
+
+  const commonIssue = validateAnthropicCommonRequest(request, true);
+  if (commonIssue) {
+    return { ok: false, issue: commonIssue };
+  }
+
+  return { ok: true };
+}
+
+export function validateAnthropicCountTokensRequest(request: unknown): ValidationResult {
+  if (!isRecord(request) || !request.model || !request.messages) {
+    return invalid("Missing required fields: model or messages");
+  }
+
+  const commonIssue = validateAnthropicCommonRequest(request, false);
+  if (commonIssue) {
+    return { ok: false, issue: commonIssue };
+  }
+
+  return { ok: true };
+}
+
+function validateAnthropicCommonRequest(
+  request: Record<string, unknown>,
+  validateThinking: boolean
+): ValidationIssue | undefined {
+  if (!Array.isArray(request.messages) || request.messages.length === 0) {
+    return { message: "messages must be a non-empty array", param: "messages" };
+  }
+
+  for (const [index, message] of request.messages.entries()) {
+    if (!isRecord(message) || typeof message.role !== "string" || !MESSAGE_ROLES.has(message.role)) {
+      return { message: "messages contains an invalid role", param: `messages.${index}.role` };
+    }
+
+    if (typeof message.content !== "string" && !Array.isArray(message.content)) {
+      return { message: "message content must be a string or content block array", param: `messages.${index}.content` };
+    }
+
+    if (Array.isArray(message.content)) {
+      const issue = validateContentBlocks(message.content, `messages.${index}.content`);
+      if (issue) {
+        return issue;
+      }
+    }
+  }
+
+  if (request.tools !== undefined) {
+    if (!Array.isArray(request.tools)) {
+      return { message: "tools must be an array", param: "tools" };
+    }
+
+    for (const [index, tool] of request.tools.entries()) {
+      if (!isRecord(tool) || typeof tool.name !== "string" || !isRecord(tool.input_schema)) {
+        return { message: "tool requires name and input_schema", param: `tools.${index}` };
+      }
+    }
+  }
+
+  if (validateThinking && request.thinking !== undefined) {
+    if (!isRecord(request.thinking) || typeof request.thinking.type !== "string" || !THINKING_TYPES.has(request.thinking.type)) {
+      return { message: "thinking config has an invalid type", param: "thinking.type" };
+    }
+
+    if (
+      request.thinking.type === "enabled" &&
+      (!Number.isInteger(request.thinking.budget_tokens) || Number(request.thinking.budget_tokens) <= 0)
+    ) {
+      return { message: "enabled thinking requires positive budget_tokens", param: "thinking.budget_tokens" };
+    }
+  }
+
+  return undefined;
+}
+
+function validateContentBlocks(blocks: unknown[], path: string): ValidationIssue | undefined {
+  for (const [index, block] of blocks.entries()) {
+    if (!isRecord(block) || typeof block.type !== "string" || !CONTENT_BLOCK_TYPES.has(block.type)) {
+      return { message: "content block has an invalid type", param: `${path}.${index}.type` };
+    }
+
+    if (block.type === "text" && typeof block.text !== "string") {
+      return { message: "text block requires text", param: `${path}.${index}.text` };
+    }
+
+    if ((block.type === "image" || block.type === "document") && !isRecord(block.source)) {
+      return { message: `${block.type} block requires source`, param: `${path}.${index}.source` };
+    }
+
+    if (block.type === "tool_result" && typeof block.tool_use_id !== "string") {
+      return { message: "tool_result block requires tool_use_id", param: `${path}.${index}.tool_use_id` };
+    }
+
+    if (
+      block.type === "tool_use" &&
+      (typeof block.id !== "string" || typeof block.name !== "string" || !isRecord(block.input))
+    ) {
+      return { message: "tool_use block requires id, name, and input", param: `${path}.${index}` };
+    }
+
+    if (block.type === "thinking" && typeof block.thinking !== "string") {
+      return { message: "thinking block requires thinking", param: `${path}.${index}.thinking` };
+    }
+
+    if (block.type === "redacted_thinking" && typeof block.data !== "string") {
+      return { message: "redacted_thinking block requires data", param: `${path}.${index}.data` };
+    }
+  }
+
+  return undefined;
+}
+
+function invalid(message: string): ValidationResult {
+  return { ok: false, issue: { message } };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/core/validation/anthropicSchemas.ts
+++ b/src/core/validation/anthropicSchemas.ts
@@ -18,8 +18,18 @@ const CONTENT_BLOCK_TYPES = new Set([
 const THINKING_TYPES = new Set(["enabled", "adaptive", "disabled"]);
 
 export function validateAnthropicMessageRequest(request: unknown): ValidationResult {
-  if (!isRecord(request) || !request.model || !request.messages || !request.max_tokens) {
+  if (
+    !isRecord(request) ||
+    typeof request.model !== "string" ||
+    request.model.trim().length === 0 ||
+    !Array.isArray(request.messages) ||
+    request.max_tokens === undefined
+  ) {
     return invalid("Missing required fields: model, messages, or max_tokens");
+  }
+
+  if (!Number.isInteger(request.max_tokens) || Number(request.max_tokens) <= 0) {
+    return { ok: false, issue: { message: "max_tokens must be a positive integer", param: "max_tokens" } };
   }
 
   const commonIssue = validateAnthropicCommonRequest(request, true);
@@ -31,7 +41,12 @@ export function validateAnthropicMessageRequest(request: unknown): ValidationRes
 }
 
 export function validateAnthropicCountTokensRequest(request: unknown): ValidationResult {
-  if (!isRecord(request) || !request.model || !request.messages) {
+  if (
+    !isRecord(request) ||
+    typeof request.model !== "string" ||
+    request.model.trim().length === 0 ||
+    !Array.isArray(request.messages)
+  ) {
     return invalid("Missing required fields: model or messages");
   }
 

--- a/src/core/validation/geminiSchemas.ts
+++ b/src/core/validation/geminiSchemas.ts
@@ -173,19 +173,7 @@ function validateGeminiGenerationConfig(config: unknown): ValidationIssue | unde
 }
 
 function validateFunctionResponseIds(contents: unknown[]): ValidationIssue | undefined {
-  const functionCallIds = new Set<string>();
-
-  for (const content of contents) {
-    if (!isRecord(content) || !Array.isArray(content.parts)) {
-      continue;
-    }
-
-    for (const part of content.parts) {
-      if (isRecord(part) && isRecord(part.functionCall) && typeof part.functionCall.id === "string") {
-        functionCallIds.add(part.functionCall.id);
-      }
-    }
-  }
+  const seenFunctionCallIds = new Set<string>();
 
   for (const [contentIndex, content] of contents.entries()) {
     if (!isRecord(content) || !Array.isArray(content.parts)) {
@@ -193,12 +181,15 @@ function validateFunctionResponseIds(contents: unknown[]): ValidationIssue | und
     }
 
     for (const [partIndex, part] of content.parts.entries()) {
+      if (isRecord(part) && isRecord(part.functionCall) && typeof part.functionCall.id === "string") {
+        seenFunctionCallIds.add(part.functionCall.id);
+      }
       if (
         isRecord(part) &&
         isRecord(part.functionResponse) &&
         typeof part.functionResponse.id === "string" &&
-        functionCallIds.size > 0 &&
-        !functionCallIds.has(part.functionResponse.id)
+        seenFunctionCallIds.size > 0 &&
+        !seenFunctionCallIds.has(part.functionResponse.id)
       ) {
         return {
           message: "functionResponse id does not match a previous functionCall id",

--- a/src/core/validation/geminiSchemas.ts
+++ b/src/core/validation/geminiSchemas.ts
@@ -1,0 +1,220 @@
+export type ValidationIssue = {
+  message: string;
+  param?: string | null;
+};
+
+export type ValidationResult = { ok: true } | { ok: false; issue: ValidationIssue };
+
+const CONTENT_ROLES = new Set(["user", "model"]);
+const RESPONSE_MIME_TYPES = new Set(["text/plain", "application/json", "text/x.enum"]);
+
+export function validateGeminiGenerateContentRequest(request: unknown): ValidationResult {
+  if (!isRecord(request) || !Array.isArray(request.contents) || request.contents.length === 0) {
+    return invalid("Request must contain at least one content item", "contents");
+  }
+
+  const contentIssue = validateGeminiContents(request.contents);
+  if (contentIssue) {
+    return { ok: false, issue: contentIssue };
+  }
+
+  const toolIssue = validateGeminiTools(request.tools);
+  if (toolIssue) {
+    return { ok: false, issue: toolIssue };
+  }
+
+  const generationConfigIssue = validateGeminiGenerationConfig(request.generationConfig);
+  if (generationConfigIssue) {
+    return { ok: false, issue: generationConfigIssue };
+  }
+
+  const idMismatchIssue = validateFunctionResponseIds(request.contents);
+  if (idMismatchIssue) {
+    return { ok: false, issue: idMismatchIssue };
+  }
+
+  return { ok: true };
+}
+
+export function validateGeminiCountTokensRequest(request: unknown): ValidationResult {
+  if (!isRecord(request)) {
+    return invalid("Request must contain at least one content item", "contents");
+  }
+
+  const payload = isRecord(request.generateContentRequest) ? request.generateContentRequest : { contents: request.contents };
+  return validateGeminiGenerateContentRequest(payload);
+}
+
+function validateGeminiContents(contents: unknown[]): ValidationIssue | undefined {
+  for (const [contentIndex, content] of contents.entries()) {
+    if (!isRecord(content)) {
+      return { message: "Each content item must be an object", param: `contents.${contentIndex}` };
+    }
+
+    if (content.role !== undefined && (typeof content.role !== "string" || !CONTENT_ROLES.has(content.role))) {
+      return { message: "content role is invalid", param: `contents.${contentIndex}.role` };
+    }
+
+    if (!Array.isArray(content.parts) || content.parts.length === 0) {
+      return { message: "Each content item must contain at least one part", param: `contents.${contentIndex}.parts` };
+    }
+
+    for (const [partIndex, part] of content.parts.entries()) {
+      const issue = validateGeminiPart(part, `contents.${contentIndex}.parts.${partIndex}`);
+      if (issue) {
+        return issue;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function validateGeminiPart(part: unknown, path: string): ValidationIssue | undefined {
+  if (!isRecord(part)) {
+    return { message: "part must be an object", param: path };
+  }
+
+  const partFields = [
+    "text",
+    "inlineData",
+    "fileData",
+    "functionCall",
+    "functionResponse",
+    "executableCode",
+    "codeExecutionResult",
+  ].filter((field) => part[field] !== undefined);
+
+  if (partFields.length !== 1) {
+    return { message: "part must contain exactly one supported field", param: path };
+  }
+
+  if (part.text !== undefined && typeof part.text !== "string") {
+    return { message: "text part requires string text", param: `${path}.text` };
+  }
+
+  if (part.inlineData !== undefined) {
+    if (!isRecord(part.inlineData) || typeof part.inlineData.mimeType !== "string" || typeof part.inlineData.data !== "string") {
+      return { message: "inlineData requires mimeType and data", param: `${path}.inlineData` };
+    }
+  }
+
+  if (part.fileData !== undefined) {
+    if (!isRecord(part.fileData) || typeof part.fileData.fileUri !== "string") {
+      return { message: "fileData requires fileUri", param: `${path}.fileData.fileUri` };
+    }
+  }
+
+  if (part.functionCall !== undefined) {
+    if (!isRecord(part.functionCall) || typeof part.functionCall.name !== "string" || !isRecord(part.functionCall.args)) {
+      return { message: "functionCall requires name and args", param: `${path}.functionCall` };
+    }
+  }
+
+  if (part.functionResponse !== undefined) {
+    if (!isRecord(part.functionResponse) || typeof part.functionResponse.name !== "string" || !isRecord(part.functionResponse.response)) {
+      return { message: "functionResponse requires name and response", param: `${path}.functionResponse` };
+    }
+  }
+
+  return undefined;
+}
+
+function validateGeminiTools(tools: unknown): ValidationIssue | undefined {
+  if (tools === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(tools)) {
+    return { message: "tools must be an array", param: "tools" };
+  }
+
+  for (const [index, tool] of tools.entries()) {
+    if (!isRecord(tool)) {
+      return { message: "tool must be an object", param: `tools.${index}` };
+    }
+
+    if (tool.functionDeclarations !== undefined) {
+      if (!Array.isArray(tool.functionDeclarations)) {
+        return { message: "functionDeclarations must be an array", param: `tools.${index}.functionDeclarations` };
+      }
+
+      for (const [declarationIndex, declaration] of tool.functionDeclarations.entries()) {
+        if (!isRecord(declaration) || typeof declaration.name !== "string") {
+          return {
+            message: "function declaration requires name",
+            param: `tools.${index}.functionDeclarations.${declarationIndex}.name`,
+          };
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function validateGeminiGenerationConfig(config: unknown): ValidationIssue | undefined {
+  if (config === undefined) {
+    return undefined;
+  }
+
+  if (!isRecord(config)) {
+    return { message: "generationConfig must be an object", param: "generationConfig" };
+  }
+
+  if (
+    config.responseMimeType !== undefined &&
+    (typeof config.responseMimeType !== "string" || !RESPONSE_MIME_TYPES.has(config.responseMimeType))
+  ) {
+    return { message: "responseMimeType is invalid", param: "generationConfig.responseMimeType" };
+  }
+
+  return undefined;
+}
+
+function validateFunctionResponseIds(contents: unknown[]): ValidationIssue | undefined {
+  const functionCallIds = new Set<string>();
+
+  for (const content of contents) {
+    if (!isRecord(content) || !Array.isArray(content.parts)) {
+      continue;
+    }
+
+    for (const part of content.parts) {
+      if (isRecord(part) && isRecord(part.functionCall) && typeof part.functionCall.id === "string") {
+        functionCallIds.add(part.functionCall.id);
+      }
+    }
+  }
+
+  for (const [contentIndex, content] of contents.entries()) {
+    if (!isRecord(content) || !Array.isArray(content.parts)) {
+      continue;
+    }
+
+    for (const [partIndex, part] of content.parts.entries()) {
+      if (
+        isRecord(part) &&
+        isRecord(part.functionResponse) &&
+        typeof part.functionResponse.id === "string" &&
+        functionCallIds.size > 0 &&
+        !functionCallIds.has(part.functionResponse.id)
+      ) {
+        return {
+          message: "functionResponse id does not match a previous functionCall id",
+          param: `contents.${contentIndex}.parts.${partIndex}.functionResponse.id`,
+        };
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function invalid(message: string, param?: string): ValidationResult {
+  return { ok: false, issue: { message, param: param || null } };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/core/validation/openaiSchemas.ts
+++ b/src/core/validation/openaiSchemas.ts
@@ -169,7 +169,7 @@ function validateOpenAITool(tool: unknown, path: string): ValidationIssue | unde
     return { message: "tool must be an object", param: path, code: "invalid_request" };
   }
 
-  if (tool.type !== undefined && (typeof tool.type !== "string" || !TOOL_TYPES.has(tool.type))) {
+  if (typeof tool.type !== "string" || !TOOL_TYPES.has(tool.type)) {
     return { message: "tool has an invalid type", param: `${path}.type`, code: "invalid_request" };
   }
 

--- a/src/core/validation/openaiSchemas.ts
+++ b/src/core/validation/openaiSchemas.ts
@@ -1,0 +1,226 @@
+export type ValidationIssue = {
+  message: string;
+  param?: string | null;
+  code?: string;
+};
+
+export type ValidationResult = { ok: true } | { ok: false; issue: ValidationIssue };
+
+const CHAT_ROLES = new Set(["developer", "system", "user", "assistant", "tool", "function"]);
+const CHAT_PART_TYPES = new Set(["text", "image_url", "input_audio", "file", "refusal"]);
+const RESPONSE_FORMAT_TYPES = new Set(["text", "json_object", "json_schema"]);
+const TOOL_TYPES = new Set(["function", "custom"]);
+
+export function validateOpenAIChatCompletionRequest(request: unknown): ValidationResult {
+  if (!isRecord(request) || !request.model) {
+    return missingParameter("model");
+  }
+
+  if (!Array.isArray(request.messages) || request.messages.length === 0) {
+    return missingParameter("messages");
+  }
+
+  for (const [index, message] of request.messages.entries()) {
+    if (!isRecord(message) || typeof message.role !== "string" || !CHAT_ROLES.has(message.role)) {
+      return invalidRequest("messages contains an invalid role", `messages.${index}.role`);
+    }
+
+    const content = message.content;
+    if (content !== undefined && content !== null && typeof content !== "string" && !Array.isArray(content)) {
+      return invalidRequest("message content must be a string, null, or content part array", `messages.${index}.content`);
+    }
+
+    if (Array.isArray(content)) {
+      const partIssue = validateOpenAIChatContentParts(content, `messages.${index}.content`);
+      if (partIssue) {
+        return { ok: false, issue: partIssue };
+      }
+    }
+  }
+
+  if (request.response_format !== undefined) {
+    const responseFormatIssue = validateResponseFormat(request.response_format);
+    if (responseFormatIssue) {
+      return { ok: false, issue: responseFormatIssue };
+    }
+  }
+
+  if (request.tools !== undefined) {
+    if (!Array.isArray(request.tools)) {
+      return invalidRequest("tools must be an array", "tools");
+    }
+
+    for (const [index, tool] of request.tools.entries()) {
+      const toolIssue = validateOpenAITool(tool, `tools.${index}`);
+      if (toolIssue) {
+        return { ok: false, issue: toolIssue };
+      }
+    }
+  }
+
+  return { ok: true };
+}
+
+export function validateOpenAIResponsesRequest(request: unknown): ValidationResult {
+  if (!isRecord(request)) {
+    return invalidRequest("request body must be an object");
+  }
+
+  if (request.input !== undefined && typeof request.input !== "string" && !Array.isArray(request.input) && !isRecord(request.input)) {
+    return invalidRequest("input must be a string, object, or array", "input");
+  }
+
+  if (request.text !== undefined) {
+    const text = request.text;
+    if (!isRecord(text)) {
+      return invalidRequest("text must be an object", "text");
+    }
+
+    if (text.format !== undefined) {
+      const issue = validateResponseFormat(text.format);
+      if (issue) {
+        return { ok: false, issue };
+      }
+    }
+  }
+
+  if (request.tools !== undefined) {
+    if (!Array.isArray(request.tools)) {
+      return invalidRequest("tools must be an array", "tools");
+    }
+
+    for (const [index, tool] of request.tools.entries()) {
+      const issue = validateOpenAIResponseTool(tool, `tools.${index}`);
+      if (issue) {
+        return { ok: false, issue };
+      }
+    }
+  }
+
+  return { ok: true };
+}
+
+export function validateOpenAIEmbeddingsRequest(request: unknown): ValidationResult {
+  if (!isRecord(request) || !request.model) {
+    return missingParameter("model");
+  }
+
+  if (request.input === undefined) {
+    return missingParameter("input");
+  }
+
+  if (
+    typeof request.input !== "string" &&
+    !Array.isArray(request.input)
+  ) {
+    return invalidRequest("input must be a string or array", "input");
+  }
+
+  if (request.dimensions !== undefined) {
+    const dimensions = Number(request.dimensions);
+    if (!Number.isInteger(dimensions) || dimensions <= 0 || dimensions > 2048) {
+      return invalidRequest("dimensions must be an integer between 1 and 2048", "dimensions");
+    }
+  }
+
+  if (
+    request.encoding_format !== undefined &&
+    request.encoding_format !== "float" &&
+    request.encoding_format !== "base64"
+  ) {
+    return invalidRequest("encoding_format must be 'float' or 'base64'", "encoding_format");
+  }
+
+  return { ok: true };
+}
+
+function validateOpenAIChatContentParts(parts: unknown[], path: string): ValidationIssue | undefined {
+  for (const [index, part] of parts.entries()) {
+    if (!isRecord(part) || typeof part.type !== "string" || !CHAT_PART_TYPES.has(part.type)) {
+      return {
+        message: "message content part has an invalid type",
+        param: `${path}.${index}.type`,
+        code: "invalid_request",
+      };
+    }
+
+    if (part.type === "text" && typeof part.text !== "string") {
+      return { message: "text content part requires text", param: `${path}.${index}.text`, code: "invalid_request" };
+    }
+
+    if (part.type === "image_url" && part.image_url === undefined) {
+      return { message: "image_url content part requires image_url", param: `${path}.${index}.image_url`, code: "invalid_request" };
+    }
+
+    if (part.type === "input_audio" && !isRecord(part.input_audio)) {
+      return { message: "input_audio content part requires input_audio", param: `${path}.${index}.input_audio`, code: "invalid_request" };
+    }
+
+    if (part.type === "file" && !isRecord(part.file)) {
+      return { message: "file content part requires file", param: `${path}.${index}.file`, code: "invalid_request" };
+    }
+  }
+
+  return undefined;
+}
+
+function validateOpenAITool(tool: unknown, path: string): ValidationIssue | undefined {
+  if (!isRecord(tool)) {
+    return { message: "tool must be an object", param: path, code: "invalid_request" };
+  }
+
+  if (tool.type !== undefined && (typeof tool.type !== "string" || !TOOL_TYPES.has(tool.type))) {
+    return { message: "tool has an invalid type", param: `${path}.type`, code: "invalid_request" };
+  }
+
+  if (tool.type === "function" && (!isRecord(tool.function) || typeof tool.function.name !== "string")) {
+    return { message: "function tool requires function.name", param: `${path}.function.name`, code: "invalid_request" };
+  }
+
+  return undefined;
+}
+
+function validateOpenAIResponseTool(tool: unknown, path: string): ValidationIssue | undefined {
+  if (!isRecord(tool) || typeof tool.type !== "string") {
+    return { message: "tool requires a type", param: `${path}.type`, code: "invalid_request" };
+  }
+
+  if (tool.type === "function" && typeof tool.name !== "string") {
+    return { message: "function tool requires name", param: `${path}.name`, code: "invalid_request" };
+  }
+
+  return undefined;
+}
+
+function validateResponseFormat(format: unknown): ValidationIssue | undefined {
+  if (!isRecord(format) || typeof format.type !== "string" || !RESPONSE_FORMAT_TYPES.has(format.type)) {
+    return { message: "response format has an invalid type", param: "response_format.type", code: "invalid_request" };
+  }
+
+  return undefined;
+}
+
+function missingParameter(param: string): ValidationResult {
+  return {
+    ok: false,
+    issue: {
+      message: `Missing required parameter: ${param}`,
+      code: "missing_parameter",
+    },
+  };
+}
+
+function invalidRequest(message: string, param?: string): ValidationResult {
+  return {
+    ok: false,
+    issue: {
+      message,
+      param: param || null,
+      code: "invalid_request",
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,4 +1,4 @@
-import { MockModel, MockTestCase } from '../types';
+import { MockModel } from '../types';
 import { thinkingTestCases, functionTestCases, markdownTestCases } from './testCases';
 import { ImgData } from './base64Img';
 

--- a/src/data/testCases.ts
+++ b/src/data/testCases.ts
@@ -1,4 +1,4 @@
-import { MockModel, MockTestCase } from '../types';
+import { MockTestCase } from '../types';
 import { ImgData } from './base64Img';
 // Thinking model test cases
 export const thinkingTestCases: MockTestCase[] = [

--- a/src/fixtures/anthropic/messages.simple.json
+++ b/src/fixtures/anthropic/messages.simple.json
@@ -1,0 +1,18 @@
+{
+  "id": "msg_mock_0001",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4-5",
+  "content": [
+    {
+      "type": "text",
+      "text": "Hello from Claude mock."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 8,
+    "output_tokens": 4
+  }
+}

--- a/src/fixtures/anthropic/messages.simple_text.json
+++ b/src/fixtures/anthropic/messages.simple_text.json
@@ -1,0 +1,14 @@
+{
+  "provider": "anthropic",
+  "endpoint": "messages",
+  "scenario": "simple_text",
+  "data": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Hello from Anthropic mock."
+      }
+    ],
+    "stop_reason": "end_turn"
+  }
+}

--- a/src/fixtures/anthropic/messages.stream-tool-use.jsonl
+++ b/src/fixtures/anthropic/messages.stream-tool-use.jsonl
@@ -1,0 +1,4 @@
+{"event":"message_start","data":{"type":"message_start","message":{"id":"msg_mock_0001","type":"message","role":"assistant","content":[]}}}
+{"event":"content_block_start","data":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_mock_0001","name":"get_order","input":{}}}}
+{"event":"content_block_delta","data":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"order_id\":\"A100\"}"}}}
+{"event":"message_stop","data":{"type":"message_stop"}}

--- a/src/fixtures/anthropic/messages.thinking.json
+++ b/src/fixtures/anthropic/messages.thinking.json
@@ -1,0 +1,19 @@
+{
+  "id": "msg_mock_0001",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4-5",
+  "content": [
+    {
+      "type": "thinking",
+      "thinking": "We need to inspect the request and return a deterministic mock answer.",
+      "signature": "sig_mock_0001"
+    },
+    {
+      "type": "text",
+      "text": "The deterministic thinking mock completed the request."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null
+}

--- a/src/fixtures/anthropic/messages.tool-use.json
+++ b/src/fixtures/anthropic/messages.tool-use.json
@@ -1,0 +1,18 @@
+{
+  "id": "msg_mock_0001",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4-5",
+  "content": [
+    {
+      "type": "tool_use",
+      "id": "toolu_mock_0001",
+      "name": "get_order",
+      "input": {
+        "order_id": "A100"
+      }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null
+}

--- a/src/fixtures/gemini/generate.function-call.json
+++ b/src/fixtures/gemini/generate.function-call.json
@@ -1,0 +1,22 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "functionCall": {
+              "id": "func_mock_0001",
+              "name": "get_order",
+              "args": {
+                "order_id": "A100"
+              }
+            }
+          }
+        ]
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ]
+}

--- a/src/fixtures/gemini/generate.simple.json
+++ b/src/fixtures/gemini/generate.simple.json
@@ -1,0 +1,17 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "text": "Hello from Gemini mock."
+          }
+        ]
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "responseId": "gemini_mock_0001"
+}

--- a/src/fixtures/gemini/generate.stream.jsonl
+++ b/src/fixtures/gemini/generate.stream.jsonl
@@ -1,0 +1,2 @@
+{"data":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello from "}]},"index":0}]}}
+{"data":{"candidates":[{"content":{"role":"model","parts":[{"text":"Gemini mock."}]},"index":0,"finishReason":"STOP"}],"responseId":"gemini_mock_0001"}}

--- a/src/fixtures/gemini/generate.structured-output.json
+++ b/src/fixtures/gemini/generate.structured-output.json
@@ -1,0 +1,16 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "text": "{\"name\":\"UltraWidget\",\"price\":19.99,\"currency\":\"USD\"}"
+          }
+        ]
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ]
+}

--- a/src/fixtures/gemini/generateContent.simple_text.json
+++ b/src/fixtures/gemini/generateContent.simple_text.json
@@ -1,0 +1,20 @@
+{
+  "provider": "gemini",
+  "endpoint": "generateContent",
+  "scenario": "simple_text",
+  "data": {
+    "candidates": [
+      {
+        "content": {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Hello from Gemini mock."
+            }
+          ]
+        },
+        "finishReason": "STOP"
+      }
+    ]
+  }
+}

--- a/src/fixtures/openai/chat.vision.json
+++ b/src/fixtures/openai/chat.vision.json
@@ -1,0 +1,16 @@
+{
+  "id": "chatcmpl_mock_0001",
+  "object": "chat.completion",
+  "created": 0,
+  "model": "gpt-4.1-mini",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "The mock chat model inspected the image input."
+      },
+      "finish_reason": "stop"
+    }
+  ]
+}

--- a/src/fixtures/openai/image.generation.json
+++ b/src/fixtures/openai/image.generation.json
@@ -1,0 +1,9 @@
+{
+  "created": 0,
+  "data": [
+    {
+      "url": "mock://images/img_mock_0001",
+      "revised_prompt": "A deterministic mock image generation."
+    }
+  ]
+}

--- a/src/fixtures/openai/responses.simple.json
+++ b/src/fixtures/openai/responses.simple.json
@@ -1,0 +1,22 @@
+{
+  "id": "resp_mock_0001",
+  "object": "response",
+  "created_at": 0,
+  "status": "completed",
+  "model": "gpt-4.1-mini",
+  "output": [
+    {
+      "id": "msg_mock_0001",
+      "type": "message",
+      "status": "completed",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "The agent harness protocol upgrade is on track across all provider mocks.",
+          "annotations": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/fixtures/openai/responses.simple_text.json
+++ b/src/fixtures/openai/responses.simple_text.json
@@ -1,0 +1,12 @@
+{
+  "provider": "openai",
+  "endpoint": "responses",
+  "scenario": "simple_text",
+  "data": {
+    "output_text": "Hello from OpenAI mock.",
+    "usage": {
+      "input_tokens": 4,
+      "output_tokens": 4
+    }
+  }
+}

--- a/src/fixtures/openai/responses.stream.jsonl
+++ b/src/fixtures/openai/responses.stream.jsonl
@@ -1,0 +1,3 @@
+{"event":"response.created","data":{"type":"response.created","response":{"id":"resp_mock_0001","object":"response","status":"in_progress"}}}
+{"event":"response.output_text.delta","data":{"type":"response.output_text.delta","delta":"Hello from the mock Responses API."}}
+{"event":"response.completed","data":{"type":"response.completed","response":{"id":"resp_mock_0001","object":"response","status":"completed"}}}

--- a/src/fixtures/openai/responses.structured-output.json
+++ b/src/fixtures/openai/responses.structured-output.json
@@ -1,0 +1,21 @@
+{
+  "id": "resp_mock_0001",
+  "object": "response",
+  "status": "completed",
+  "model": "gpt-4.1-mini",
+  "output": [
+    {
+      "id": "msg_mock_0001",
+      "type": "message",
+      "status": "completed",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "{\"name\":\"UltraWidget\",\"price\":19.99,\"currency\":\"USD\"}",
+          "annotations": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/fixtures/openai/responses.tool-call.json
+++ b/src/fixtures/openai/responses.tool-call.json
@@ -1,0 +1,16 @@
+{
+  "id": "resp_mock_0001",
+  "object": "response",
+  "status": "completed",
+  "model": "gpt-4.1-mini",
+  "output": [
+    {
+      "id": "fc_mock_0001",
+      "type": "function_call",
+      "status": "completed",
+      "call_id": "call_mock_0001",
+      "name": "get_order",
+      "arguments": "{\"order_id\":\"A100\"}"
+    }
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import app from './app';
+import { formatEndpointCatalog } from './core/http/endpointCatalog';
 import { loadModelMapping, getMappedModelName } from './config/modelMapping';
 
 const PORT = process.env.PORT || 3000;
@@ -17,15 +18,7 @@ app.listen(PORT, () => {
   console.log(`📍 Server address: http://${HOST}:${PORT}`);
   console.log(`🔍 Verbose logging: ${global.verboseLogging ? 'enabled' : 'disabled'}`);
   console.log(`📖 API Documentation:`);
-  console.log(`   • GET  /health - Health check`);
-  console.log(`   • GET  /v1/models - Get OpenAI model list`);
-  console.log(`   • POST /v1/chat/completions - OpenAI chat completions`);
-  console.log(`   • POST /v1/images/generations - OpenAI image generation`);
-  console.log(`   • GET  /anthropic/v1/models - Get Anthropic model list`);
-  console.log(`   • POST /anthropic/v1/messages - Anthropic message API`);
-  console.log(`   • GET  /v1beta/models - Get Gemini model list`);
-  console.log(`   • POST /v1beta/models/{model}:generateContent - Gemini content generation`);
-  console.log(`   • POST /v1beta/models/{model}:streamGenerateContent - Gemini streaming generation`);
+  formatEndpointCatalog().forEach((line) => console.log(line));
   console.log(`\n✨ Available models:`);
   console.log(`   OpenAI Compatible:`);
   console.log(`   - ${getMappedModelName('mock-gpt-thinking')}: Model supporting thought process`);
@@ -39,12 +32,24 @@ app.listen(PORT, () => {
   console.log(`   - ${getMappedModelName('gemini-1.5-flash')}: Fast and efficient model`);
   console.log(`   - ${getMappedModelName('gemini-pro')}: Versatile model for various tasks`);
   console.log(`   - ${getMappedModelName('gemini-pro-vision')}: Multimodal model for text and images`);
-  console.log(`\n🔗 Usage example:`);
-  console.log(`   curl -X POST http://localhost:${PORT}/v1/chat/completions \\`);
+  console.log(`\n🔗 Usage examples:`);
+  console.log(`   # OpenAI Responses API`);
+  console.log(`   curl -X POST http://localhost:${PORT}/v1/responses \\`);
   console.log(`     -H "Content-Type: application/json" \\`);
   console.log(`     -d '{`);
-  console.log(`       "model": "${getMappedModelName('gpt-4-mock')}",`);
-  console.log(`       "messages": [{"role": "user", "content": "Hello"}]`);
+  console.log(`       "model": "gpt-4.1-mini",`);
+  console.log(`       "input": "Hello from a local agent harness"`);
   console.log(`     }'`);
+  console.log(``);
+  console.log(`   # Anthropic Messages API`);
+  console.log(`   curl -X POST http://localhost:${PORT}/v1/messages \\`);
+  console.log(`     -H "Content-Type: application/json" \\`);
+  console.log(`     -H "anthropic-version: 2023-06-01" \\`);
+  console.log(`     -d '{"model":"claude-sonnet-4-5","max_tokens":256,"messages":[{"role":"user","content":"Hello"}]}'`);
+  console.log(``);
+  console.log(`   # Gemini GenerateContent API`);
+  console.log(`   curl -X POST http://localhost:${PORT}/v1beta/models/gemini-1.5-flash:generateContent \\`);
+  console.log(`     -H "Content-Type: application/json" \\`);
+  console.log(`     -d '{"contents":[{"role":"user","parts":[{"text":"Hello"}]}]}'`);
   console.log(`\n💡 Use CLI for more options: npm run build && npx mock-openai-api --help`);
 }); 

--- a/src/providers/anthropic/files.routes.ts
+++ b/src/providers/anthropic/files.routes.ts
@@ -1,0 +1,2 @@
+export { providerFilesRouter as anthropicFilesRouter } from "../files.routes";
+export { default } from "../files.routes";

--- a/src/providers/anthropic/messages.routes.ts
+++ b/src/providers/anthropic/messages.routes.ts
@@ -1,0 +1,90 @@
+import { Request, RequestHandler, Response, Router } from "express";
+import { getInjectedProviderError } from "../../core/errors/errorInjector";
+import { ProviderError } from "../../core/errors/providerErrors";
+import { readMockStreamChunkDelay } from "../../core/http/mockControls";
+import { selectScenario } from "../../core/scenarioEngine";
+import { ANTHROPIC_SSE_HEADERS } from "../../core/sse/anthropicSse";
+import { sendEncodedSse } from "../../core/sse/streamWriter";
+import {
+  AnthropicMessageCreateRequest,
+  countAnthropicMessageTokens,
+  createAnthropicMessage,
+  encodeAnthropicMessageStream,
+  ServiceResult,
+} from "./messages.service";
+
+export const anthropicMessagesRouter: Router = Router();
+
+anthropicMessagesRouter.post("/count_tokens", handleCountTokens as RequestHandler);
+anthropicMessagesRouter.post("/", handleCreateMessage as RequestHandler);
+
+export async function handleCreateMessage(req: Request, res: Response) {
+  const injectedError = getInjectedProviderError({
+    provider: "anthropic",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const request = req.body as AnthropicMessageCreateRequest;
+  const result = createAnthropicMessage(request, selectAnthropicScenario(req));
+
+  if (!result.ok) {
+    return sendError(res, result.error);
+  }
+
+  if (request.stream) {
+    await sendEncodedSse(
+      res,
+      ANTHROPIC_SSE_HEADERS,
+      encodeAnthropicMessageStream(result.value),
+      readMockStreamChunkDelay(req)
+    );
+    return;
+  }
+
+  res.json(result.value);
+}
+
+function handleCountTokens(req: Request, res: Response) {
+  const injectedError = getInjectedProviderError({
+    provider: "anthropic",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  sendResult(res, countAnthropicMessageTokens(req.body as AnthropicMessageCreateRequest));
+}
+
+function selectAnthropicScenario(req: Request) {
+  return selectScenario({
+    provider: "anthropic",
+    endpoint: req.path,
+    method: req.method,
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+    body: req.body,
+    model: typeof req.body?.model === "string" ? req.body.model : undefined,
+  });
+}
+
+function sendResult<T>(res: Response, result: ServiceResult<T>) {
+  if (!result.ok) {
+    return sendError(res, result.error);
+  }
+
+  res.json(result.value);
+}
+
+function sendError(res: Response, error: ProviderError) {
+  res.status(error.status).json(error.body);
+}
+
+export default anthropicMessagesRouter;

--- a/src/providers/anthropic/messages.service.ts
+++ b/src/providers/anthropic/messages.service.ts
@@ -1,0 +1,448 @@
+import { buildAnthropicError, ProviderError } from "../../core/errors/providerErrors";
+import { IdFactory } from "../../core/state/idFactory";
+import { ScenarioName, ScenarioSelection } from "../../core/scenarioEngine";
+import { anthropicEvent } from "../../core/sse/anthropicSse";
+import { estimateTokens } from "../../core/usage/tokenEstimator";
+import { buildAnthropicUsage } from "../../core/usage/usageBuilder";
+import {
+  validateAnthropicCountTokensRequest,
+  validateAnthropicMessageRequest,
+} from "../../core/validation/anthropicSchemas";
+
+export type AnthropicMessageCreateRequest = {
+  model?: string;
+  messages?: AnthropicInputMessage[];
+  system?: string | AnthropicContentBlock[];
+  max_tokens?: number;
+  metadata?: Record<string, unknown>;
+  stop_sequences?: string[];
+  stream?: boolean;
+  temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  tools?: AnthropicTool[];
+  tool_choice?: unknown;
+  thinking?: { type: "enabled" | "adaptive" | "disabled"; budget_tokens?: number; effort?: string };
+  mcp_servers?: unknown[];
+  service_tier?: "auto" | "standard_only";
+};
+
+export type AnthropicInputMessage = {
+  role: "user" | "assistant";
+  content: string | AnthropicContentBlock[];
+};
+
+export type AnthropicContentBlock =
+  | { type: "text"; text: string; cache_control?: object }
+  | { type: "image"; source: unknown; cache_control?: object }
+  | { type: "document"; source: unknown; title?: string; cache_control?: object }
+  | {
+      type: "tool_result";
+      tool_use_id: string;
+      content?: string | AnthropicContentBlock[];
+      is_error?: boolean;
+      cache_control?: object;
+    };
+
+export type AnthropicTool = {
+  name: string;
+  description?: string;
+  input_schema: object;
+  strict?: boolean;
+  cache_control?: object;
+  eager_input_streaming?: boolean;
+};
+
+export type AnthropicOutputBlock =
+  | { type: "text"; text: string }
+  | { type: "thinking"; thinking: string; signature?: string }
+  | { type: "redacted_thinking"; data: string }
+  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> };
+
+export type AnthropicMessage = {
+  id: string;
+  type: "message";
+  role: "assistant";
+  model: string;
+  content: AnthropicOutputBlock[];
+  stop_reason: "end_turn" | "max_tokens" | "stop_sequence" | "tool_use" | "pause_turn" | "refusal" | null;
+  stop_sequence: string | null;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+};
+
+export type ServiceResult<T> = { ok: true; value: T } | { ok: false; error: ProviderError };
+
+const seededFactories = new Map<string, IdFactory>();
+const processFactory = new IdFactory();
+
+export function createAnthropicMessage(
+  request: AnthropicMessageCreateRequest,
+  selection: ScenarioSelection
+): ServiceResult<AnthropicMessage> {
+  const validationError = validateAnthropicRequest(request);
+  if (validationError) {
+    return { ok: false, error: validationError };
+  }
+
+  if (selection.scenario === "invalid_request") {
+    return { ok: false, error: buildAnthropicError(400, "Invalid mock request scenario.") };
+  }
+
+  if (selection.scenario === "rate_limit") {
+    return { ok: false, error: buildAnthropicError(429, "Mock rate limit exceeded.") };
+  }
+
+  if (selection.scenario === "invalid_tool_args") {
+    return { ok: false, error: buildAnthropicError(400, "Invalid mock tool arguments.") };
+  }
+
+  const factory = getIdFactory(selection.seed);
+  const scenario = refineScenarioFromRequest(request, selection.scenario);
+  const content = buildContentBlocks(request, scenario, factory);
+  const outputText = content.map((block) => JSON.stringify(block)).join(" ");
+  const usage = buildAnthropicUsage(
+    {
+      system: request.system,
+      messages: request.messages,
+      tools: request.tools,
+    },
+    outputText
+  );
+
+  return {
+    ok: true,
+    value: {
+      id: factory.next("message", "anthropic.messages"),
+      type: "message",
+      role: "assistant",
+      model: request.model || "claude-sonnet-4-5",
+      content,
+      stop_reason: stopReasonForScenario(request, scenario),
+      stop_sequence: null,
+      usage,
+    },
+  };
+}
+
+export function countAnthropicMessageTokens(request: AnthropicMessageCreateRequest): ServiceResult<{
+  input_tokens: number;
+}> {
+  const validationError = validateAnthropicTokenRequest(request);
+  if (validationError) {
+    return { ok: false, error: validationError };
+  }
+
+  return {
+    ok: true,
+    value: {
+      input_tokens: estimateTokens({
+        system: request.system,
+        messages: request.messages,
+        tools: request.tools,
+      }),
+    },
+  };
+}
+
+export function encodeAnthropicMessageStream(message: AnthropicMessage): string {
+  const chunks: string[] = [];
+
+  chunks.push(
+    anthropicEvent("message_start", {
+      type: "message_start",
+      message: {
+        ...message,
+        content: [],
+        stop_reason: null,
+        usage: {
+          input_tokens: message.usage.input_tokens,
+          output_tokens: 1,
+        },
+      },
+    })
+  );
+
+  message.content.forEach((block, index) => {
+    chunks.push(
+      anthropicEvent("content_block_start", {
+        type: "content_block_start",
+        index,
+        content_block: contentBlockStart(block),
+      })
+    );
+
+    if (block.type === "text") {
+      splitText(block.text).forEach((text) => {
+        chunks.push(
+          anthropicEvent("content_block_delta", {
+            type: "content_block_delta",
+            index,
+            delta: { type: "text_delta", text },
+          })
+        );
+      });
+    }
+
+    if (block.type === "tool_use") {
+      splitJson(JSON.stringify(block.input)).forEach((partial_json) => {
+        chunks.push(
+          anthropicEvent("content_block_delta", {
+            type: "content_block_delta",
+            index,
+            delta: { type: "input_json_delta", partial_json },
+          })
+        );
+      });
+    }
+
+    if (block.type === "thinking") {
+      chunks.push(
+        anthropicEvent("content_block_delta", {
+          type: "content_block_delta",
+          index,
+          delta: { type: "thinking_delta", thinking: block.thinking },
+        })
+      );
+      chunks.push(
+        anthropicEvent("content_block_delta", {
+          type: "content_block_delta",
+          index,
+          delta: { type: "signature_delta", signature: block.signature || "sig_mock_0001" },
+        })
+      );
+    }
+
+    chunks.push(anthropicEvent("content_block_stop", { type: "content_block_stop", index }));
+  });
+
+  chunks.push(
+    anthropicEvent("message_delta", {
+      type: "message_delta",
+      delta: {
+        stop_reason: message.stop_reason,
+        stop_sequence: null,
+      },
+      usage: {
+        output_tokens: message.usage.output_tokens,
+      },
+    })
+  );
+  chunks.push(anthropicEvent("message_stop", { type: "message_stop" }));
+
+  return chunks.join("");
+}
+
+function validateAnthropicRequest(request: AnthropicMessageCreateRequest): ProviderError | undefined {
+  const result = validateAnthropicMessageRequest(request);
+  return result.ok ? undefined : buildAnthropicError(400, result.issue.message);
+}
+
+function validateAnthropicTokenRequest(request: AnthropicMessageCreateRequest): ProviderError | undefined {
+  const result = validateAnthropicCountTokensRequest(request);
+  return result.ok ? undefined : buildAnthropicError(400, result.issue.message);
+}
+
+function refineScenarioFromRequest(
+  request: AnthropicMessageCreateRequest,
+  scenario: ScenarioName
+): ScenarioName {
+  if (hasToolResult(request.messages)) {
+    return "tool_result";
+  }
+
+  if (request.thinking && request.thinking.type !== "disabled") {
+    return "thinking";
+  }
+
+  if ((scenario === "simple_text" || scenario === "stream_text") && request.tools && request.tools.length > 1) {
+    return "parallel_tools";
+  }
+
+  if ((scenario === "simple_text" || scenario === "stream_text") && request.tools && request.tools.length > 0) {
+    return "tool_call";
+  }
+
+  return scenario;
+}
+
+function buildContentBlocks(
+  request: AnthropicMessageCreateRequest,
+  scenario: ScenarioName,
+  factory: IdFactory
+): AnthropicOutputBlock[] {
+  if (scenario === "tool_call") {
+    return [
+      { type: "text", text: "I'll check the requested information." },
+      buildToolUseBlock(factory, request.tools?.[0]?.name || "get_order"),
+    ];
+  }
+
+  if (scenario === "parallel_tools") {
+    const tools = request.tools && request.tools.length > 0 ? request.tools : fallbackTools();
+    return tools.slice(0, 4).map((tool) => buildToolUseBlock(factory, tool.name));
+  }
+
+  if (scenario === "tool_result") {
+    return [
+      {
+        type: "text",
+        text: `The tool result has been processed: ${extractToolResult(request.messages)}`,
+      },
+    ];
+  }
+
+  if (scenario === "thinking") {
+    return [
+      {
+        type: "thinking",
+        thinking: "We need to inspect the request and return a deterministic mock answer.",
+        signature: factory.next("message", "anthropic.thinking.signature"),
+      },
+      { type: "text", text: "The deterministic thinking mock completed the request." },
+    ];
+  }
+
+  if (scenario === "refusal") {
+    return [{ type: "text", text: "I cannot comply with this mock request." }];
+  }
+
+  if (scenario === "file_reference") {
+    return [{ type: "text", text: "The mock Claude model acknowledged the file reference." }];
+  }
+
+  if (scenario === "vision") {
+    return [{ type: "text", text: "The mock Claude model inspected the image input." }];
+  }
+
+  if (scenario === "pause_turn") {
+    return [{ type: "text", text: "The mock Claude turn is paused for external continuation." }];
+  }
+
+  return [{ type: "text", text: "Hello from Claude mock." }];
+}
+
+function buildToolUseBlock(factory: IdFactory, name: string): AnthropicOutputBlock {
+  return {
+    type: "tool_use",
+    id: factory.next("toolUse", `anthropic.messages.${name}`),
+    name,
+    input: toolInput(name),
+  };
+}
+
+function toolInput(name: string): Record<string, unknown> {
+  if (name.includes("weather")) {
+    return { city: "Tokyo" };
+  }
+
+  return { order_id: "A100" };
+}
+
+function fallbackTools(): AnthropicTool[] {
+  return [
+    { name: "get_order", input_schema: { type: "object" } },
+    { name: "get_weather", input_schema: { type: "object" } },
+  ];
+}
+
+function stopReasonForScenario(
+  request: AnthropicMessageCreateRequest,
+  scenario: ScenarioName
+): AnthropicMessage["stop_reason"] {
+  if (request.max_tokens !== undefined && request.max_tokens <= 1) {
+    return "max_tokens";
+  }
+
+  if (scenario === "tool_call" || scenario === "parallel_tools") {
+    return "tool_use";
+  }
+
+  if (scenario === "refusal") {
+    return "refusal";
+  }
+
+  if (scenario === "pause_turn") {
+    return "pause_turn";
+  }
+
+  return "end_turn";
+}
+
+function contentBlockStart(block: AnthropicOutputBlock): AnthropicOutputBlock {
+  if (block.type === "text") {
+    return { type: "text", text: "" };
+  }
+
+  if (block.type === "tool_use") {
+    return { ...block, input: {} };
+  }
+
+  if (block.type === "thinking") {
+    return { type: "thinking", thinking: "", signature: "" };
+  }
+
+  return block;
+}
+
+function hasToolResult(messages: AnthropicInputMessage[] | undefined): boolean {
+  return Boolean(messages?.some((message) => containsToolResult(message.content)));
+}
+
+function containsToolResult(content: string | AnthropicContentBlock[]): boolean {
+  return Array.isArray(content) && content.some((block) => block.type === "tool_result");
+}
+
+function extractToolResult(messages: AnthropicInputMessage[] | undefined): string {
+  if (!messages) {
+    return "{}";
+  }
+
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) {
+      continue;
+    }
+
+    const block = message.content.find((content) => content.type === "tool_result");
+    if (block?.type === "tool_result") {
+      return typeof block.content === "string" ? block.content : JSON.stringify(block.content || {});
+    }
+  }
+
+  return "{}";
+}
+
+function splitText(text: string): string[] {
+  const words = text.split(" ");
+  const chunks: string[] = [];
+
+  for (let index = 0; index < words.length; index += 3) {
+    chunks.push(words.slice(index, index + 3).join(" ") + (index + 3 < words.length ? " " : ""));
+  }
+
+  return chunks;
+}
+
+function splitJson(json: string): string[] {
+  const midpoint = Math.ceil(json.length / 2);
+  return [json.slice(0, midpoint), json.slice(midpoint)].filter(Boolean);
+}
+
+function getIdFactory(seed: string): IdFactory {
+  if (seed === "default") {
+    return processFactory;
+  }
+
+  const existing = seededFactories.get(seed);
+  if (existing) {
+    return existing;
+  }
+
+  const factory = new IdFactory(seed);
+  seededFactories.set(seed, factory);
+  return factory;
+}

--- a/src/providers/anthropic/models.routes.ts
+++ b/src/providers/anthropic/models.routes.ts
@@ -1,0 +1,9 @@
+import { RequestHandler, Router } from "express";
+import { handleGetModels } from "../../controllers/anthropicController";
+
+export const anthropicModelsRouter: Router = Router();
+export const handleListAnthropicModels = handleGetModels;
+
+anthropicModelsRouter.get("/", handleListAnthropicModels as RequestHandler);
+
+export default anthropicModelsRouter;

--- a/src/providers/files.routes.ts
+++ b/src/providers/files.routes.ts
@@ -1,0 +1,163 @@
+import { Request, RequestHandler, Response, Router } from "express";
+import multer from "multer";
+import { getInjectedProviderError } from "../core/errors/errorInjector";
+import { buildAnthropicError, buildOpenAIError, ProviderError } from "../core/errors/providerErrors";
+import { IdFactory } from "../core/state/idFactory";
+
+export const providerFilesRouter: Router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+const idFactory = new IdFactory();
+const openAIFiles = new Map<string, OpenAIFileObject>();
+const anthropicFiles = new Map<string, AnthropicFileObject>();
+
+type OpenAIFileObject = {
+  id: string;
+  object: "file";
+  bytes: number;
+  created_at: number;
+  filename: string;
+  purpose: string;
+};
+
+type AnthropicFileObject = {
+  id: string;
+  type: "file";
+  filename: string;
+  mime_type: string;
+  size_bytes: number;
+  created_at: string;
+};
+
+providerFilesRouter.post("/", upload.any(), handleCreateFile as RequestHandler);
+providerFilesRouter.get("/", handleListFiles as RequestHandler);
+providerFilesRouter.get("/:file_id", handleGetFile as RequestHandler);
+providerFilesRouter.delete("/:file_id", handleDeleteFile as RequestHandler);
+
+function handleCreateFile(req: Request, res: Response) {
+  const injectedError = getInjectedFileError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  if (isAnthropicRequest(req)) {
+    const file = firstUploadedFile(req);
+    const record: AnthropicFileObject = {
+      id: idFactory.next("file", "anthropic.files"),
+      type: "file",
+      filename: file?.originalname || readBodyString(req, "filename") || "mock-upload.txt",
+      mime_type: file?.mimetype || readBodyString(req, "mime_type") || "application/octet-stream",
+      size_bytes: file?.size || Number(readBodyString(req, "size_bytes") || 0),
+      created_at: new Date(0).toISOString(),
+    };
+    anthropicFiles.set(record.id, record);
+    return res.json(record);
+  }
+
+  const file = firstUploadedFile(req);
+  const record: OpenAIFileObject = {
+    id: idFactory.next("file", "openai.files"),
+    object: "file",
+    bytes: file?.size || Number(readBodyString(req, "bytes") || 0),
+    created_at: Math.floor(Date.now() / 1000),
+    filename: file?.originalname || readBodyString(req, "filename") || "mock-upload.txt",
+    purpose: readBodyString(req, "purpose") || "assistants",
+  };
+  openAIFiles.set(record.id, record);
+  res.json(record);
+}
+
+function handleListFiles(req: Request, res: Response) {
+  const injectedError = getInjectedFileError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  if (isAnthropicRequest(req)) {
+    return res.json({
+      data: Array.from(anthropicFiles.values()),
+      has_more: false,
+      first_id: firstId(anthropicFiles),
+      last_id: lastId(anthropicFiles),
+    });
+  }
+
+  res.json({
+    object: "list",
+    data: Array.from(openAIFiles.values()),
+  });
+}
+
+function handleGetFile(req: Request, res: Response) {
+  const injectedError = getInjectedFileError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  if (isAnthropicRequest(req)) {
+    const record = anthropicFiles.get(req.params.file_id);
+    return record
+      ? res.json(record)
+      : sendError(res, buildAnthropicError(404, `File '${req.params.file_id}' was not found.`));
+  }
+
+  const record = openAIFiles.get(req.params.file_id);
+  return record
+    ? res.json(record)
+    : sendError(res, buildOpenAIError(404, `File '${req.params.file_id}' was not found.`));
+}
+
+function handleDeleteFile(req: Request, res: Response) {
+  const injectedError = getInjectedFileError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  if (isAnthropicRequest(req)) {
+    const deleted = anthropicFiles.delete(req.params.file_id);
+    return deleted
+      ? res.json({ id: req.params.file_id, type: "file_deleted", deleted: true })
+      : sendError(res, buildAnthropicError(404, `File '${req.params.file_id}' was not found.`));
+  }
+
+  const deleted = openAIFiles.delete(req.params.file_id);
+  return deleted
+    ? res.json({ id: req.params.file_id, object: "file", deleted: true })
+    : sendError(res, buildOpenAIError(404, `File '${req.params.file_id}' was not found.`));
+}
+
+function isAnthropicRequest(req: Request): boolean {
+  const provider = req.header("x-provider") || req.query.provider;
+  return Boolean(req.header("anthropic-version") || provider === "anthropic");
+}
+
+function firstUploadedFile(req: Request): Express.Multer.File | undefined {
+  const files = req.files;
+  return Array.isArray(files) ? files[0] : undefined;
+}
+
+function readBodyString(req: Request, key: string): string | undefined {
+  const value = (req.body as Record<string, unknown> | undefined)?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function firstId<T extends { id: string }>(map: Map<string, T>): string | null {
+  return Array.from(map.values())[0]?.id || null;
+}
+
+function lastId<T extends { id: string }>(map: Map<string, T>): string | null {
+  return Array.from(map.values()).at(-1)?.id || null;
+}
+
+function getInjectedFileError(req: Request): ProviderError | undefined {
+  return getInjectedProviderError({
+    provider: isAnthropicRequest(req) ? "anthropic" : "openai",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+}
+
+function sendError(res: Response, error: ProviderError) {
+  res.status(error.status).json(error.body);
+}
+
+export default providerFilesRouter;

--- a/src/providers/gemini/cachedContents.routes.ts
+++ b/src/providers/gemini/cachedContents.routes.ts
@@ -1,0 +1,107 @@
+import { Request, RequestHandler, Response, Router } from "express";
+import { getInjectedProviderError } from "../../core/errors/errorInjector";
+import { buildGeminiError, ProviderError } from "../../core/errors/providerErrors";
+import { IdFactory } from "../../core/state/idFactory";
+import { estimateTokens } from "../../core/usage/tokenEstimator";
+
+export const geminiCachedContentsRouter: Router = Router();
+const idFactory = new IdFactory();
+const cachedContents = new Map<string, GeminiCachedContent>();
+
+type GeminiCachedContent = {
+  name: string;
+  model?: string;
+  contents?: unknown[];
+  systemInstruction?: unknown;
+  tools?: unknown[];
+  createTime: string;
+  updateTime: string;
+  expireTime: string;
+  usageMetadata: {
+    totalTokenCount: number;
+  };
+};
+
+geminiCachedContentsRouter.post("/v1beta/cachedContents", handleCreateCachedContent as RequestHandler);
+geminiCachedContentsRouter.get("/v1beta/cachedContents", handleListCachedContents as RequestHandler);
+geminiCachedContentsRouter.get("/v1beta/cachedContents/:name", handleGetCachedContent as RequestHandler);
+geminiCachedContentsRouter.delete("/v1beta/cachedContents/:name", handleDeleteCachedContent as RequestHandler);
+
+function handleCreateCachedContent(req: Request, res: Response) {
+  const injectedError = getInjectedGeminiError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const body = req.body as Partial<GeminiCachedContent>;
+  const id = idFactory.next("cachedContent", "gemini.cachedContents");
+  const now = new Date(0).toISOString();
+  const cached: GeminiCachedContent = {
+    name: `cachedContents/${id}`,
+    model: body.model || "models/gemini-1.5-flash",
+    contents: body.contents || [],
+    systemInstruction: body.systemInstruction,
+    tools: body.tools || [],
+    createTime: now,
+    updateTime: now,
+    expireTime: new Date(24 * 60 * 60 * 1000).toISOString(),
+    usageMetadata: {
+      totalTokenCount: estimateTokens(body),
+    },
+  };
+
+  cachedContents.set(cached.name, cached);
+  cachedContents.set(id, cached);
+  res.json(cached);
+}
+
+function handleListCachedContents(req: Request, res: Response) {
+  const injectedError = getInjectedGeminiError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  res.json({ cachedContents: Array.from(new Set(cachedContents.values())) });
+}
+
+function handleGetCachedContent(req: Request, res: Response) {
+  const injectedError = getInjectedGeminiError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const cached = cachedContents.get(req.params.name);
+  return cached
+    ? res.json(cached)
+    : sendError(res, buildGeminiError(404, `Cached content '${req.params.name}' was not found.`));
+}
+
+function handleDeleteCachedContent(req: Request, res: Response) {
+  const injectedError = getInjectedGeminiError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const cached = cachedContents.get(req.params.name);
+  if (!cached) {
+    return sendError(res, buildGeminiError(404, `Cached content '${req.params.name}' was not found.`));
+  }
+
+  cachedContents.delete(cached.name);
+  cachedContents.delete(cached.name.replace(/^cachedContents\//, ""));
+  res.json({});
+}
+
+function getInjectedGeminiError(req: Request): ProviderError | undefined {
+  return getInjectedProviderError({
+    provider: "gemini",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+}
+
+function sendError(res: Response, error: ProviderError) {
+  res.status(error.status).json(error.body);
+}
+
+export default geminiCachedContentsRouter;

--- a/src/providers/gemini/files.routes.ts
+++ b/src/providers/gemini/files.routes.ts
@@ -83,7 +83,10 @@ function handleFinalizeResumableUpload(req: Request, res: Response) {
   }
 
   const id = req.params.upload_id;
-  const file = pendingUploads.get(id) || buildFileObject({ id });
+  const file = pendingUploads.get(id);
+  if (!file) {
+    return sendError(res, buildGeminiError(404, `Upload session '${id}' was not found.`));
+  }
 
   pendingUploads.delete(id);
   files.set(file.name, file);

--- a/src/providers/gemini/files.routes.ts
+++ b/src/providers/gemini/files.routes.ts
@@ -1,0 +1,200 @@
+import { Request, RequestHandler, Response, Router } from "express";
+import multer from "multer";
+import { getInjectedProviderError } from "../../core/errors/errorInjector";
+import { buildGeminiError, ProviderError } from "../../core/errors/providerErrors";
+import { IdFactory } from "../../core/state/idFactory";
+
+export const geminiFilesRouter: Router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+const idFactory = new IdFactory();
+const files = new Map<string, GeminiFileObject>();
+const pendingUploads = new Map<string, GeminiFileObject>();
+
+type GeminiFileObject = {
+  name: string;
+  displayName: string;
+  mimeType: string;
+  sizeBytes: string;
+  createTime: string;
+  updateTime: string;
+  expirationTime: string;
+  uri: string;
+  state: "ACTIVE";
+};
+
+geminiFilesRouter.post("/upload/v1beta/files/:upload_id", handleFinalizeResumableUpload as RequestHandler);
+geminiFilesRouter.post("/upload/v1beta/files", upload.any(), handleUploadFile as RequestHandler);
+geminiFilesRouter.get("/v1beta/files", handleListFiles as RequestHandler);
+geminiFilesRouter.get("/v1beta/files/:name", handleGetFile as RequestHandler);
+geminiFilesRouter.delete("/v1beta/files/:name", handleDeleteFile as RequestHandler);
+
+function handleUploadFile(req: Request, res: Response) {
+  const injectedError = getInjectedGeminiError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  if (isResumableUploadStart(req)) {
+    return handleStartResumableUpload(req, res);
+  }
+
+  const uploadFile = firstUploadedFile(req);
+  const id = idFactory.next("file", "gemini.files");
+  const file = buildFileObject({
+    id,
+    displayName: uploadFile?.originalname || readBodyString(req, "displayName") || "mock-upload.txt",
+    mimeType: uploadFile?.mimetype || readBodyString(req, "mimeType") || "application/octet-stream",
+    sizeBytes: String(uploadFile?.size || Number(readBodyString(req, "sizeBytes") || 0)),
+  });
+
+  files.set(file.name, file);
+  files.set(cleanFileId(file.name), file);
+  res.json(file);
+}
+
+function handleStartResumableUpload(req: Request, res: Response) {
+  const requestedFile = readRequestFile(req);
+  const id = cleanFileId(readObjectString(requestedFile, "name")) || idFactory.next("file", "gemini.files");
+  const file = buildFileObject({
+    id,
+    displayName:
+      readObjectString(requestedFile, "displayName") ||
+      readHeaderString(req, "x-goog-upload-file-name") ||
+      "mock-upload.txt",
+    mimeType:
+      readObjectString(requestedFile, "mimeType") ||
+      readHeaderString(req, "x-goog-upload-header-content-type") ||
+      "application/octet-stream",
+    sizeBytes:
+      readObjectString(requestedFile, "sizeBytes") ||
+      readHeaderString(req, "x-goog-upload-header-content-length") ||
+      "0",
+  });
+
+  pendingUploads.set(id, file);
+  res.setHeader("x-goog-upload-url", `https://generativelanguage.googleapis.com/upload/v1beta/files/${id}`);
+  res.json({});
+}
+
+function handleFinalizeResumableUpload(req: Request, res: Response) {
+  const injectedError = getInjectedGeminiError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const id = req.params.upload_id;
+  const file = pendingUploads.get(id) || buildFileObject({ id });
+
+  pendingUploads.delete(id);
+  files.set(file.name, file);
+  files.set(cleanFileId(file.name), file);
+
+  res.setHeader("x-goog-upload-status", "final");
+  res.json({ file });
+}
+
+function handleListFiles(req: Request, res: Response) {
+  const injectedError = getInjectedGeminiError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const uniqueFiles = Array.from(new Set(files.values()));
+  res.json({ files: uniqueFiles });
+}
+
+function handleGetFile(req: Request, res: Response) {
+  const injectedError = getInjectedGeminiError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const file = files.get(req.params.name);
+  return file ? res.json(file) : sendError(res, buildGeminiError(404, `File '${req.params.name}' was not found.`));
+}
+
+function handleDeleteFile(req: Request, res: Response) {
+  const injectedError = getInjectedGeminiError(req);
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const file = files.get(req.params.name);
+  if (!file) {
+    return sendError(res, buildGeminiError(404, `File '${req.params.name}' was not found.`));
+  }
+
+  files.delete(file.name);
+  files.delete(file.name.replace(/^files\//, ""));
+  res.json({});
+}
+
+function firstUploadedFile(req: Request): Express.Multer.File | undefined {
+  const uploadedFiles = req.files;
+  return Array.isArray(uploadedFiles) ? uploadedFiles[0] : undefined;
+}
+
+function readBodyString(req: Request, key: string): string | undefined {
+  const value = (req.body as Record<string, unknown> | undefined)?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function readRequestFile(req: Request): Record<string, unknown> {
+  const file = (req.body as { file?: unknown } | undefined)?.file;
+  return file && typeof file === "object" ? file as Record<string, unknown> : {};
+}
+
+function readObjectString(object: Record<string, unknown>, key: string): string | undefined {
+  const value = object[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function readHeaderString(req: Request, key: string): string | undefined {
+  const value = req.header(key);
+  return value || undefined;
+}
+
+function isResumableUploadStart(req: Request): boolean {
+  return req.header("x-goog-upload-command")?.toLowerCase().includes("start") || false;
+}
+
+function buildFileObject(input: {
+  id: string;
+  displayName?: string;
+  mimeType?: string;
+  sizeBytes?: string;
+}): GeminiFileObject {
+  const id = cleanFileId(input.id);
+  const name = `files/${id}`;
+  const now = new Date(0).toISOString();
+
+  return {
+    name,
+    displayName: input.displayName || "mock-upload.txt",
+    mimeType: input.mimeType || "application/octet-stream",
+    sizeBytes: input.sizeBytes || "0",
+    createTime: now,
+    updateTime: now,
+    expirationTime: new Date(24 * 60 * 60 * 1000).toISOString(),
+    uri: `mock://${name}`,
+    state: "ACTIVE",
+  };
+}
+
+function cleanFileId(id: string | undefined): string {
+  return (id || idFactory.next("file", "gemini.files")).replace(/^files\//, "");
+}
+
+function getInjectedGeminiError(req: Request): ProviderError | undefined {
+  return getInjectedProviderError({
+    provider: "gemini",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+}
+
+function sendError(res: Response, error: ProviderError) {
+  res.status(error.status).json(error.body);
+}
+
+export default geminiFilesRouter;

--- a/src/providers/gemini/generateContent.routes.ts
+++ b/src/providers/gemini/generateContent.routes.ts
@@ -1,0 +1,96 @@
+import { Request, RequestHandler, Response, Router } from "express";
+import { getInjectedProviderError } from "../../core/errors/errorInjector";
+import { ProviderError } from "../../core/errors/providerErrors";
+import { readMockStreamChunkDelay } from "../../core/http/mockControls";
+import { selectScenario } from "../../core/scenarioEngine";
+import { GEMINI_SSE_HEADERS } from "../../core/sse/geminiSse";
+import { sendEncodedSse } from "../../core/sse/streamWriter";
+import {
+  countGeminiTokens,
+  encodeGeminiGenerateContentStream,
+  generateGeminiContent,
+  GeminiCountTokensRequest,
+  GeminiGenerateContentRequest,
+  ServiceResult,
+} from "./generateContent.service";
+
+export const geminiGenerateContentRouter: Router = Router();
+
+geminiGenerateContentRouter.post("/:model\\:generateContent", handleGenerateContent as RequestHandler);
+geminiGenerateContentRouter.post("/:model\\:streamGenerateContent", handleGenerateContent as RequestHandler);
+geminiGenerateContentRouter.post("/:model\\:countTokens", handleCountTokens as RequestHandler);
+
+export async function handleGenerateContent(req: Request, res: Response) {
+  const injectedError = getInjectedProviderError({
+    provider: "gemini",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const request = req.body as GeminiGenerateContentRequest;
+  const result = generateGeminiContent(req.params.model, request, selectGeminiScenario(req));
+
+  if (!result.ok) {
+    return sendError(res, result.error);
+  }
+
+  if (isStreamingRequest(req)) {
+    await sendEncodedSse(
+      res,
+      GEMINI_SSE_HEADERS,
+      encodeGeminiGenerateContentStream(result.value),
+      readMockStreamChunkDelay(req)
+    );
+    return;
+  }
+
+  res.json(result.value);
+}
+
+export function handleCountTokens(req: Request, res: Response) {
+  const injectedError = getInjectedProviderError({
+    provider: "gemini",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  sendResult(res, countGeminiTokens(req.body as GeminiCountTokensRequest));
+}
+
+function selectGeminiScenario(req: Request) {
+  return selectScenario({
+    provider: "gemini",
+    endpoint: req.path,
+    method: req.method,
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+    body: req.body,
+    model: req.params.model,
+  });
+}
+
+function isStreamingRequest(req: Request): boolean {
+  return req.path.includes("streamGenerateContent") || req.query.alt === "sse";
+}
+
+function sendResult<T>(res: Response, result: ServiceResult<T>) {
+  if (!result.ok) {
+    return sendError(res, result.error);
+  }
+
+  res.json(result.value);
+}
+
+function sendError(res: Response, error: ProviderError) {
+  res.status(error.status).json(error.body);
+}
+
+export default geminiGenerateContentRouter;

--- a/src/providers/gemini/generateContent.service.ts
+++ b/src/providers/gemini/generateContent.service.ts
@@ -1,0 +1,450 @@
+import { buildGeminiError, ProviderError } from "../../core/errors/providerErrors";
+import { IdFactory } from "../../core/state/idFactory";
+import { ScenarioName, ScenarioSelection } from "../../core/scenarioEngine";
+import { geminiData } from "../../core/sse/geminiSse";
+import { estimateTokens } from "../../core/usage/tokenEstimator";
+import { buildGeminiUsage } from "../../core/usage/usageBuilder";
+import {
+  validateGeminiCountTokensRequest,
+  validateGeminiGenerateContentRequest,
+} from "../../core/validation/geminiSchemas";
+
+export type GeminiGenerateContentRequest = {
+  contents?: GeminiContent[];
+  systemInstruction?: GeminiContent;
+  tools?: GeminiTool[];
+  toolConfig?: Record<string, unknown>;
+  safetySettings?: unknown[];
+  generationConfig?: GeminiGenerationConfig;
+  cachedContent?: string;
+  serviceTier?: string;
+  store?: boolean;
+};
+
+export type GeminiContent = {
+  role?: "user" | "model";
+  parts: GeminiPart[];
+};
+
+export type GeminiPart =
+  | { text: string }
+  | { inlineData: { mimeType: string; data: string } }
+  | { fileData: { mimeType?: string; fileUri: string } }
+  | { functionCall: { id?: string; name: string; args: Record<string, unknown> } }
+  | { functionResponse: { id?: string; name: string; response: Record<string, unknown> } }
+  | { executableCode: { language: string; code: string } }
+  | { codeExecutionResult: { outcome: string; output: string } };
+
+export type GeminiTool = {
+  functionDeclarations?: Array<{
+    name: string;
+    description?: string;
+    parameters?: object;
+    response?: object;
+  }>;
+  codeExecution?: object;
+  googleSearch?: object;
+};
+
+export type GeminiGenerationConfig = {
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  candidateCount?: number;
+  maxOutputTokens?: number;
+  stopSequences?: string[];
+  responseMimeType?: "text/plain" | "application/json" | "text/x.enum";
+  responseSchema?: Record<string, unknown>;
+  thinkingConfig?: {
+    thinkingBudget?: number;
+    includeThoughts?: boolean;
+  };
+};
+
+export type GeminiCandidate = {
+  content: GeminiContent;
+  finishReason?: "STOP" | "MAX_TOKENS" | "SAFETY" | "RECITATION" | "OTHER";
+  safetyRatings?: unknown[];
+  index?: number;
+  citationMetadata?: object;
+  groundingMetadata?: object;
+};
+
+export type GeminiGenerateContentResponse = {
+  candidates?: GeminiCandidate[];
+  promptFeedback?: object;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    totalTokenCount?: number;
+    promptTokensDetails?: unknown[];
+    candidatesTokensDetails?: unknown[];
+  };
+  modelVersion?: string;
+  responseId?: string;
+};
+
+export type GeminiCountTokensRequest = {
+  contents?: GeminiContent[];
+  generateContentRequest?: GeminiGenerateContentRequest;
+};
+
+export type ServiceResult<T> = { ok: true; value: T } | { ok: false; error: ProviderError };
+
+const seededFactories = new Map<string, IdFactory>();
+const processFactory = new IdFactory();
+
+export function generateGeminiContent(
+  model: string,
+  request: GeminiGenerateContentRequest,
+  selection: ScenarioSelection
+): ServiceResult<GeminiGenerateContentResponse> {
+  const validationError = validateGenerateContentRequest(request);
+  if (validationError) {
+    return { ok: false, error: validationError };
+  }
+
+  const functionResponseError = validateFunctionResponseIds(request);
+  if (functionResponseError) {
+    return { ok: false, error: functionResponseError };
+  }
+
+  if (selection.scenario === "invalid_request") {
+    return { ok: false, error: buildGeminiError(400, "Invalid mock request scenario.") };
+  }
+
+  if (selection.scenario === "rate_limit") {
+    return { ok: false, error: buildGeminiError(429, "Mock rate limit exceeded.") };
+  }
+
+  if (selection.scenario === "invalid_tool_args") {
+    return { ok: false, error: buildGeminiError(400, "Invalid mock tool arguments.") };
+  }
+
+  const scenario = refineScenarioFromRequest(request, selection.scenario);
+  const factory = getIdFactory(selection.seed);
+  const parts = buildResponseParts(request, scenario, factory);
+  const finishReason = scenario === "safety_block" || scenario === "refusal" ? "SAFETY" : "STOP";
+  const responseId = factory.next("gemini", "gemini.generate");
+  const groundingMetadata = hasGoogleSearchTool(request)
+    ? {
+        groundingChunks: [{ web: { title: "Mock Search Result", uri: "mock://search/result" } }],
+        groundingSupports: [{ segment: { text: "mock search result" }, groundingChunkIndices: [0] }],
+      }
+    : undefined;
+  const response: GeminiGenerateContentResponse = {
+    candidates: [
+      {
+        content: {
+          role: "model",
+          parts,
+        },
+        finishReason,
+        index: 0,
+        safetyRatings: safetyRatings(finishReason),
+        groundingMetadata,
+      },
+    ],
+    usageMetadata: buildGeminiUsage(request, parts),
+    modelVersion: cleanModelName(model),
+    responseId,
+  };
+
+  if (scenario === "safety_block" || scenario === "refusal") {
+    response.promptFeedback = {
+      blockReason: "SAFETY",
+      safetyRatings: safetyRatings("SAFETY"),
+    };
+  }
+
+  return { ok: true, value: response };
+}
+
+export function countGeminiTokens(request: GeminiCountTokensRequest): ServiceResult<{ totalTokens: number }> {
+  const validationResult = validateGeminiCountTokensRequest(request);
+
+  if (!validationResult.ok) {
+    return { ok: false, error: buildGeminiError(400, validationResult.issue.message) };
+  }
+
+  const payload = request.generateContentRequest || { contents: request.contents };
+  return {
+    ok: true,
+    value: {
+      totalTokens: estimateTokens(payload),
+    },
+  };
+}
+
+export function encodeGeminiGenerateContentStream(response: GeminiGenerateContentResponse): string {
+  const candidate = response.candidates?.[0];
+  const parts = candidate?.content.parts || [];
+  const functionParts = parts.filter((part) => "functionCall" in part);
+
+  if (functionParts.length > 0) {
+    return geminiData({
+      candidates: [
+        {
+          content: { role: "model", parts: functionParts },
+          index: 0,
+          finishReason: "STOP",
+        },
+      ],
+      responseId: response.responseId,
+    });
+  }
+
+  const text = parts.map((part) => ("text" in part ? part.text : "")).join("");
+  const chunks = splitText(text);
+  const encoded = chunks
+    .map((chunk, index) =>
+      geminiData({
+        candidates: [
+          {
+            content: { role: "model", parts: [{ text: chunk }] },
+            index: 0,
+            finishReason: index === chunks.length - 1 ? candidate?.finishReason || "STOP" : undefined,
+            safetyRatings: index === chunks.length - 1 ? candidate?.safetyRatings || [] : undefined,
+          },
+        ],
+        usageMetadata: index === chunks.length - 1 ? response.usageMetadata : undefined,
+        modelVersion: index === chunks.length - 1 ? response.modelVersion : undefined,
+        responseId: index === chunks.length - 1 ? response.responseId : undefined,
+      })
+    )
+    .join("");
+
+  return encoded;
+}
+
+function validateGenerateContentRequest(
+  request: GeminiGenerateContentRequest
+): ProviderError | undefined {
+  const result = validateGeminiGenerateContentRequest(request);
+  return result.ok ? undefined : buildGeminiError(400, result.issue.message);
+}
+
+function refineScenarioFromRequest(
+  request: GeminiGenerateContentRequest,
+  scenario: ScenarioName
+): ScenarioName {
+  if (containsFunctionResponse(request)) {
+    return "tool_result";
+  }
+
+  if (request.generationConfig?.responseMimeType === "application/json" || request.generationConfig?.responseSchema) {
+    return "structured_json";
+  }
+
+  if (request.generationConfig?.responseMimeType === "text/x.enum") {
+    return "structured_json";
+  }
+
+  if (scenario === "simple_text" && countFunctionDeclarations(request.tools) > 1) {
+    return "parallel_tools";
+  }
+
+  if (scenario === "simple_text" && countFunctionDeclarations(request.tools) > 0) {
+    return "tool_call";
+  }
+
+  return scenario;
+}
+
+function buildResponseParts(
+  request: GeminiGenerateContentRequest,
+  scenario: ScenarioName,
+  factory: IdFactory
+): GeminiPart[] {
+  if (hasCodeExecutionTool(request)) {
+    return [
+      { executableCode: { language: "PYTHON", code: 'print("mock code execution")' } },
+      { codeExecutionResult: { outcome: "OUTCOME_OK", output: "mock code execution\n" } },
+    ];
+  }
+
+  if (hasGoogleSearchTool(request)) {
+    return [{ text: "The mock Gemini model returned a grounded search response." }];
+  }
+
+  if (scenario === "tool_call") {
+    return [buildFunctionCallPart(factory, firstFunctionName(request.tools))];
+  }
+
+  if (scenario === "parallel_tools") {
+    const names = functionNames(request.tools);
+    const selectedNames = names.length > 1 ? names : ["get_order", "get_weather"];
+    return selectedNames.slice(0, 4).map((name) => buildFunctionCallPart(factory, name));
+  }
+
+  if (scenario === "tool_result") {
+    return [{ text: `The function response was processed: ${extractFunctionResponse(request)}` }];
+  }
+
+  if (scenario === "structured_json") {
+    if (request.generationConfig?.responseMimeType === "text/x.enum") {
+      return [{ text: firstEnumValue(request.generationConfig.responseSchema) || "positive" }];
+    }
+
+    return [{ text: '{"name":"UltraWidget","price":19.99,"currency":"USD"}' }];
+  }
+
+  if (scenario === "safety_block" || scenario === "refusal") {
+    return [{ text: "The mock request was blocked by deterministic safety controls." }];
+  }
+
+  if (scenario === "vision") {
+    return [{ text: "The mock Gemini model inspected the image input." }];
+  }
+
+  if (scenario === "multimodal_audio") {
+    return [{ text: "The mock Gemini model acknowledged the audio input." }];
+  }
+
+  if (scenario === "multimodal_video") {
+    return [{ text: "The mock Gemini model acknowledged the video input." }];
+  }
+
+  if (scenario === "file_reference") {
+    return [{ text: "The mock Gemini model acknowledged the file reference." }];
+  }
+
+  return [{ text: "Hello from Gemini mock." }];
+}
+
+function buildFunctionCallPart(factory: IdFactory, name: string): GeminiPart {
+  return {
+    functionCall: {
+      id: factory.next("functionCall", `gemini.generate.${name}`),
+      name,
+      args: functionArgs(name),
+    },
+  };
+}
+
+function functionArgs(name: string): Record<string, unknown> {
+  if (name.includes("weather")) {
+    return { city: "Tokyo" };
+  }
+
+  return { order_id: "A100" };
+}
+
+function firstFunctionName(tools: GeminiTool[] | undefined): string {
+  return functionNames(tools)[0] || "get_order";
+}
+
+function functionNames(tools: GeminiTool[] | undefined): string[] {
+  return (tools || []).flatMap((tool) =>
+    (tool.functionDeclarations || []).map((declaration) => declaration.name)
+  );
+}
+
+function countFunctionDeclarations(tools: GeminiTool[] | undefined): number {
+  return functionNames(tools).length;
+}
+
+function containsFunctionResponse(request: GeminiGenerateContentRequest): boolean {
+  return Boolean(
+    request.contents?.some((content) =>
+      content.parts.some((part) => "functionResponse" in part && Boolean(part.functionResponse))
+    )
+  );
+}
+
+function collectFunctionCallIds(request: GeminiGenerateContentRequest): Set<string> {
+  const ids = new Set<string>();
+
+  for (const content of request.contents || []) {
+    for (const part of content.parts || []) {
+      if ("functionCall" in part && part.functionCall.id) {
+        ids.add(part.functionCall.id);
+      }
+    }
+  }
+
+  return ids;
+}
+
+function validateFunctionResponseIds(request: GeminiGenerateContentRequest): ProviderError | undefined {
+  const functionCallIds = collectFunctionCallIds(request);
+
+  if (functionCallIds.size === 0) {
+    return undefined;
+  }
+
+  for (const content of request.contents || []) {
+    for (const part of content.parts || []) {
+      if ("functionResponse" in part && part.functionResponse.id && !functionCallIds.has(part.functionResponse.id)) {
+        return buildGeminiError(400, "functionResponse id does not match a previous functionCall id");
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function hasCodeExecutionTool(request: GeminiGenerateContentRequest): boolean {
+  return Boolean(request.tools?.some((tool) => tool.codeExecution));
+}
+
+function hasGoogleSearchTool(request: GeminiGenerateContentRequest): boolean {
+  return Boolean(request.tools?.some((tool) => tool.googleSearch));
+}
+
+function extractFunctionResponse(request: GeminiGenerateContentRequest): string {
+  for (const content of request.contents || []) {
+    const part = content.parts.find((item) => "functionResponse" in item);
+    if (part && "functionResponse" in part) {
+      return JSON.stringify(part.functionResponse.response);
+    }
+  }
+
+  return "{}";
+}
+
+function firstEnumValue(schema: Record<string, unknown> | undefined): string | undefined {
+  const values = schema?.enum;
+  return Array.isArray(values) && typeof values[0] === "string" ? values[0] : undefined;
+}
+
+function safetyRatings(finishReason: string): unknown[] {
+  const probability = finishReason === "SAFETY" ? "HIGH" : "NEGLIGIBLE";
+
+  return [
+    { category: "HARM_CATEGORY_HATE_SPEECH", probability },
+    { category: "HARM_CATEGORY_HARASSMENT", probability: "NEGLIGIBLE" },
+    { category: "HARM_CATEGORY_DANGEROUS_CONTENT", probability },
+    { category: "HARM_CATEGORY_SEXUALLY_EXPLICIT", probability: "NEGLIGIBLE" },
+  ];
+}
+
+function splitText(text: string): string[] {
+  const words = text.split(" ");
+  const chunks: string[] = [];
+
+  for (let index = 0; index < words.length; index += 3) {
+    chunks.push(words.slice(index, index + 3).join(" ") + (index + 3 < words.length ? " " : ""));
+  }
+
+  return chunks.length > 0 ? chunks : [text];
+}
+
+function cleanModelName(model: string): string {
+  return model.replace(/^models\//, "");
+}
+
+function getIdFactory(seed: string): IdFactory {
+  if (seed === "default") {
+    return processFactory;
+  }
+
+  const existing = seededFactories.get(seed);
+  if (existing) {
+    return existing;
+  }
+
+  const factory = new IdFactory(seed);
+  seededFactories.set(seed, factory);
+  return factory;
+}

--- a/src/providers/gemini/generateContent.service.ts
+++ b/src/providers/gemini/generateContent.service.ts
@@ -368,8 +368,16 @@ function collectFunctionCallIds(request: GeminiGenerateContentRequest): Set<stri
 
 function validateFunctionResponseIds(request: GeminiGenerateContentRequest): ProviderError | undefined {
   const functionCallIds = collectFunctionCallIds(request);
+  const hasFunctionResponseId = (request.contents || []).some((content) =>
+    (content.parts || []).some(
+      (part) => "functionResponse" in part && Boolean(part.functionResponse?.id)
+    )
+  );
 
   if (functionCallIds.size === 0) {
+    if (hasFunctionResponseId) {
+      return buildGeminiError(400, "functionResponse id does not match a previous functionCall id");
+    }
     return undefined;
   }
 

--- a/src/providers/gemini/models.routes.ts
+++ b/src/providers/gemini/models.routes.ts
@@ -1,0 +1,9 @@
+import { RequestHandler, Router } from "express";
+import { handleGetGeminiModels } from "../../controllers/geminiController";
+
+export const geminiModelsRouter: Router = Router();
+export const handleListGeminiModels = handleGetGeminiModels;
+
+geminiModelsRouter.get("/", handleListGeminiModels as RequestHandler);
+
+export default geminiModelsRouter;

--- a/src/providers/gemini/tokens.routes.ts
+++ b/src/providers/gemini/tokens.routes.ts
@@ -1,0 +1,8 @@
+import { RequestHandler, Router } from "express";
+import { handleCountTokens } from "./generateContent.routes";
+
+export const geminiTokensRouter: Router = Router();
+
+geminiTokensRouter.post("/:model\\:countTokens", handleCountTokens as RequestHandler);
+
+export default geminiTokensRouter;

--- a/src/providers/openai/chat.routes.ts
+++ b/src/providers/openai/chat.routes.ts
@@ -1,0 +1,102 @@
+import { Request, RequestHandler, Response, Router } from "express";
+import { getInjectedProviderError } from "../../core/errors/errorInjector";
+import { ProviderError } from "../../core/errors/providerErrors";
+import { readMockStreamChunkDelay } from "../../core/http/mockControls";
+import { selectScenario } from "../../core/scenarioEngine";
+import { OPENAI_SSE_HEADERS } from "../../core/sse/openaiSse";
+import { sendEncodedSse } from "../../core/sse/streamWriter";
+import {
+  ChatCompletionCreateRequest,
+  createOpenAIChatCompletion,
+  deleteOpenAIChatCompletion,
+  encodeOpenAIChatCompletionStream,
+  getOpenAIChatCompletion,
+  listOpenAIChatMessages,
+  ServiceResult,
+  updateOpenAIChatCompletion,
+} from "./chat.service";
+
+export const openAIChatRouter: Router = Router();
+
+openAIChatRouter.post("/", handleCreateChatCompletion as RequestHandler);
+openAIChatRouter.get("/:completion_id/messages", handleListMessages as RequestHandler);
+openAIChatRouter.get("/:completion_id", handleGetChatCompletion as RequestHandler);
+openAIChatRouter.post("/:completion_id", handleUpdateChatCompletion as RequestHandler);
+openAIChatRouter.delete("/:completion_id", handleDeleteChatCompletion as RequestHandler);
+
+export async function handleCreateChatCompletion(req: Request, res: Response) {
+  const injectedError = getInjectedProviderError({
+    provider: "openai",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const request = req.body as ChatCompletionCreateRequest;
+  const result = createOpenAIChatCompletion(request, selectOpenAIChatScenario(req));
+
+  if (!result.ok) {
+    return sendError(res, result.error);
+  }
+
+  if (request.stream) {
+    await sendEncodedSse(
+      res,
+      OPENAI_SSE_HEADERS,
+      encodeOpenAIChatCompletionStream(
+        result.value.completion,
+        result.value.scenario,
+        Boolean(request.stream_options?.include_usage)
+      ),
+      readMockStreamChunkDelay(req)
+    );
+    return;
+  }
+
+  res.json(result.value.completion);
+}
+
+function handleGetChatCompletion(req: Request, res: Response) {
+  sendResult(res, getOpenAIChatCompletion(req.params.completion_id));
+}
+
+function handleUpdateChatCompletion(req: Request, res: Response) {
+  sendResult(res, updateOpenAIChatCompletion(req.params.completion_id, req.body));
+}
+
+function handleDeleteChatCompletion(req: Request, res: Response) {
+  sendResult(res, deleteOpenAIChatCompletion(req.params.completion_id));
+}
+
+function handleListMessages(req: Request, res: Response) {
+  sendResult(res, listOpenAIChatMessages(req.params.completion_id));
+}
+
+function selectOpenAIChatScenario(req: Request) {
+  return selectScenario({
+    provider: "openai",
+    endpoint: req.path,
+    method: req.method,
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+    body: req.body,
+    model: typeof req.body?.model === "string" ? req.body.model : undefined,
+  });
+}
+
+function sendResult<T>(res: Response, result: ServiceResult<T>) {
+  if (!result.ok) {
+    return sendError(res, result.error);
+  }
+
+  res.json(result.value);
+}
+
+function sendError(res: Response, error: ProviderError) {
+  res.status(error.status).json(error.body);
+}
+
+export default openAIChatRouter;

--- a/src/providers/openai/chat.service.ts
+++ b/src/providers/openai/chat.service.ts
@@ -334,7 +334,7 @@ export function encodeOpenAIChatCompletionStream(
     openAIData({
       ...base,
       choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
-      usage: includeUsage ? null : completion.usage,
+      usage: includeUsage ? null : undefined,
     })
   );
 

--- a/src/providers/openai/chat.service.ts
+++ b/src/providers/openai/chat.service.ts
@@ -1,0 +1,548 @@
+import { buildOpenAIError, ProviderError } from "../../core/errors/providerErrors";
+import { IdFactory } from "../../core/state/idFactory";
+import { MemoryStateStore, MockStateRecord } from "../../core/state/memoryStore";
+import { ScenarioName, ScenarioSelection } from "../../core/scenarioEngine";
+import { openAIDone, openAIData } from "../../core/sse/openaiSse";
+import { buildOpenAIChatUsage, OpenAIChatUsage } from "../../core/usage/usageBuilder";
+import {
+  validateOpenAIChatCompletionRequest,
+  ValidationIssue,
+} from "../../core/validation/openaiSchemas";
+
+export type ChatRole = "developer" | "system" | "user" | "assistant" | "tool" | "function";
+
+export type ChatContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } | string }
+  | { type: "input_audio"; input_audio: { data?: string; format?: string } }
+  | { type: "file"; file: { file_id?: string; file_data?: string; filename?: string } }
+  | { type: "refusal"; refusal: string };
+
+export type ChatMessage = {
+  role: ChatRole;
+  content?: string | ChatContentPart[] | null;
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: ChatToolCall[];
+};
+
+export type ChatTool = {
+  type?: "function" | "custom";
+  name?: string;
+  function?: {
+    name?: string;
+    description?: string;
+    parameters?: object;
+  };
+  custom?: object;
+};
+
+export type ChatToolCall = {
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string;
+  };
+};
+
+export type ChatCompletionCreateRequest = {
+  model?: string;
+  messages?: ChatMessage[];
+  tools?: ChatTool[];
+  tool_choice?: "none" | "auto" | "required" | object;
+  parallel_tool_calls?: boolean;
+  response_format?: { type?: "text" | "json_object" | "json_schema"; json_schema?: object };
+  stream?: boolean;
+  stream_options?: { include_usage?: boolean; include_obfuscation?: boolean };
+  metadata?: Record<string, string>;
+  seed?: number;
+  functions?: Array<{ name: string; description?: string; parameters?: object }>;
+  function_call?: string | { name: string };
+  modalities?: string[];
+  audio?: object;
+  reasoning_effort?: "minimal" | "low" | "medium" | "high";
+};
+
+export type ChatCompletionObject = {
+  id: string;
+  object: "chat.completion";
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: ChatMessage;
+    finish_reason: "stop" | "tool_calls" | "length" | "content_filter";
+  }>;
+  usage: OpenAIChatUsage;
+  system_fingerprint: string;
+  metadata?: Record<string, string>;
+};
+
+export type ChatCompletionChunk = {
+  id: string;
+  object: "chat.completion.chunk";
+  created: number;
+  model: string;
+  system_fingerprint: string;
+  choices: Array<{
+    index: number;
+    delta: Partial<ChatMessage> & {
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: "function";
+        function?: {
+          name?: string;
+          arguments?: string;
+        };
+      }>;
+    };
+    finish_reason: "stop" | "tool_calls" | null;
+  }>;
+  usage?: OpenAIChatUsage | null;
+};
+
+export type ChatCompletionRecord = MockStateRecord & {
+  completion: ChatCompletionObject;
+  messages: ChatMessage[];
+};
+
+export type ServiceResult<T> = { ok: true; value: T } | { ok: false; error: ProviderError };
+
+export const openAIChatStore = new MemoryStateStore();
+
+const seededFactories = new Map<string, IdFactory>();
+const processFactory = new IdFactory();
+
+export function createOpenAIChatCompletion(
+  request: ChatCompletionCreateRequest,
+  selection: ScenarioSelection
+): ServiceResult<{ completion: ChatCompletionObject; messages: ChatMessage[]; scenario: ScenarioName }> {
+  const validationError = validateChatRequest(request);
+  if (validationError) {
+    return { ok: false, error: validationError };
+  }
+
+  if (selection.scenario === "invalid_request") {
+    return { ok: false, error: buildOpenAIError(400, "Invalid mock request scenario.") };
+  }
+
+  if (selection.scenario === "rate_limit") {
+    return { ok: false, error: buildOpenAIError(429, "Mock rate limit exceeded.") };
+  }
+
+  if (selection.scenario === "invalid_tool_args") {
+    return { ok: false, error: buildOpenAIError(400, "Invalid mock tool arguments.", "tools") };
+  }
+
+  const scenario = refineScenarioFromRequest(request, selection.scenario);
+  const factory = getIdFactory(selection.seed);
+  const outputMessage = buildAssistantMessage(request, scenario, factory);
+  const outputText = outputMessage.content || JSON.stringify(outputMessage.tool_calls || []);
+  const usage = buildOpenAIChatUsage(request.messages || [], outputText);
+  const completion: ChatCompletionObject = {
+    id: factory.next("chatCompletion", "openai.chat"),
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: request.model || "gpt-4.1-mini",
+    choices: [
+      {
+        index: 0,
+        message: outputMessage,
+        finish_reason: outputMessage.tool_calls ? "tool_calls" : "stop",
+      },
+    ],
+    usage,
+    system_fingerprint: "fp_mock_openai_chat",
+    metadata: request.metadata || {},
+  };
+  const messages = [...(request.messages || []), outputMessage];
+
+  openAIChatStore.create<ChatCompletionRecord>("chatCompletions", {
+    id: completion.id,
+    provider: "openai",
+    completion,
+    messages,
+  });
+
+  return { ok: true, value: { completion, messages, scenario } };
+}
+
+export function getOpenAIChatCompletion(completionId: string): ServiceResult<ChatCompletionObject> {
+  const record = openAIChatStore.get<ChatCompletionRecord>("chatCompletions", completionId);
+
+  if (!record) {
+    return { ok: false, error: buildOpenAIError(404, `Chat completion '${completionId}' was not found.`) };
+  }
+
+  return { ok: true, value: record.completion };
+}
+
+export function updateOpenAIChatCompletion(
+  completionId: string,
+  patch: { metadata?: Record<string, string> }
+): ServiceResult<ChatCompletionObject> {
+  const record = openAIChatStore.get<ChatCompletionRecord>("chatCompletions", completionId);
+
+  if (!record) {
+    return { ok: false, error: buildOpenAIError(404, `Chat completion '${completionId}' was not found.`) };
+  }
+
+  const completion = {
+    ...record.completion,
+    metadata: patch.metadata || record.completion.metadata || {},
+  };
+  openAIChatStore.update<ChatCompletionRecord>("chatCompletions", completionId, { completion });
+
+  return { ok: true, value: completion };
+}
+
+export function deleteOpenAIChatCompletion(completionId: string): ServiceResult<{
+  id: string;
+  object: "chat.completion.deleted";
+  deleted: boolean;
+}> {
+  const deleted = openAIChatStore.delete("chatCompletions", completionId);
+
+  if (!deleted) {
+    return { ok: false, error: buildOpenAIError(404, `Chat completion '${completionId}' was not found.`) };
+  }
+
+  return { ok: true, value: { id: completionId, object: "chat.completion.deleted", deleted: true } };
+}
+
+export function listOpenAIChatMessages(completionId: string): ServiceResult<{
+  object: "list";
+  data: ChatMessage[];
+  first_id: string | null;
+  last_id: string | null;
+  has_more: false;
+}> {
+  const record = openAIChatStore.get<ChatCompletionRecord>("chatCompletions", completionId);
+
+  if (!record) {
+    return { ok: false, error: buildOpenAIError(404, `Chat completion '${completionId}' was not found.`) };
+  }
+
+  const messages = record.messages.map((message, index) => ({
+    id: `chatmsg_mock_${String(index + 1).padStart(4, "0")}`,
+    ...message,
+  }));
+
+  return {
+    ok: true,
+    value: {
+      object: "list",
+      data: messages,
+      first_id: messages[0]?.id || null,
+      last_id: messages.at(-1)?.id || null,
+      has_more: false,
+    },
+  };
+}
+
+export function encodeOpenAIChatCompletionStream(
+  completion: ChatCompletionObject,
+  scenario: ScenarioName,
+  includeUsage: boolean
+): string {
+  const choice = completion.choices[0];
+  const message = choice.message;
+  const base = {
+    id: completion.id,
+    object: "chat.completion.chunk" as const,
+    created: completion.created,
+    model: completion.model,
+    system_fingerprint: completion.system_fingerprint,
+  };
+  const chunks: string[] = [
+    openAIData({
+      ...base,
+      choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+      usage: null,
+    }),
+  ];
+
+  if (scenario === "tool_call" || scenario === "parallel_tools") {
+    for (const [index, toolCall] of (message.tool_calls || []).entries()) {
+      chunks.push(
+        openAIData({
+          ...base,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index,
+                    id: toolCall.id,
+                    type: "function",
+                    function: { name: toolCall.function.name, arguments: "" },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+          usage: null,
+        })
+      );
+      chunks.push(
+        openAIData({
+          ...base,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index,
+                    function: { arguments: toolCall.function.arguments },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+          usage: null,
+        })
+      );
+    }
+    chunks.push(
+      openAIData({
+        ...base,
+        choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+        usage: includeUsage ? completion.usage : null,
+      })
+    );
+    chunks.push(openAIDone());
+    return chunks.join("");
+  }
+
+  for (const chunk of splitText(String(message.content || ""))) {
+    chunks.push(
+      openAIData({
+        ...base,
+        choices: [{ index: 0, delta: { content: chunk }, finish_reason: null }],
+        usage: null,
+      })
+    );
+  }
+
+  chunks.push(
+    openAIData({
+      ...base,
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: includeUsage ? null : completion.usage,
+    })
+  );
+
+  if (includeUsage) {
+    chunks.push(
+      openAIData({
+        ...base,
+        choices: [],
+        usage: completion.usage,
+      })
+    );
+  }
+
+  chunks.push(openAIDone());
+  return chunks.join("");
+}
+
+function validateChatRequest(request: ChatCompletionCreateRequest): ProviderError | undefined {
+  const result = validateOpenAIChatCompletionRequest(request);
+  return result.ok ? undefined : openAIValidationError(result.issue);
+}
+
+function refineScenarioFromRequest(
+  request: ChatCompletionCreateRequest,
+  scenario: ScenarioName
+): ScenarioName {
+  if (hasToolResult(request.messages)) {
+    return "tool_result";
+  }
+
+  if (hasMultipleTools(request)) {
+    return "parallel_tools";
+  }
+
+  if (hasTools(request)) {
+    return "tool_call";
+  }
+
+  if (request.response_format?.type === "json_schema" || request.response_format?.type === "json_object") {
+    return "structured_json";
+  }
+
+  const multimodal = inferChatMultimodalScenario(request.messages || []);
+  if (multimodal) {
+    return multimodal;
+  }
+
+  return scenario === "stream_text" ? "simple_text" : scenario;
+}
+
+function buildAssistantMessage(
+  request: ChatCompletionCreateRequest,
+  scenario: ScenarioName,
+  factory: IdFactory
+): ChatMessage {
+  if (scenario === "tool_call" || scenario === "parallel_tools") {
+    const names = toolNames(request);
+    const selectedNames = scenario === "parallel_tools" ? names.slice(0, 4) : names.slice(0, 1);
+    const fallback = scenario === "parallel_tools" ? ["get_order", "get_weather"] : ["get_order"];
+
+    return {
+      role: "assistant",
+      content: null,
+      tool_calls: (selectedNames.length > 0 ? selectedNames : fallback).map((name) => ({
+        id: factory.next("call", `openai.chat.${name}`),
+        type: "function",
+        function: {
+          name,
+          arguments: JSON.stringify(toolArguments(name)),
+        },
+      })),
+    };
+  }
+
+  if (scenario === "tool_result") {
+    return {
+      role: "assistant",
+      content: `The mock tool result was processed successfully: ${extractToolResult(request.messages)}`,
+    };
+  }
+
+  if (scenario === "structured_json") {
+    return {
+      role: "assistant",
+      content: '{"name":"UltraWidget","price":19.99,"currency":"USD"}',
+    };
+  }
+
+  if (scenario === "vision") {
+    return { role: "assistant", content: "The mock chat model inspected the image input." };
+  }
+
+  if (scenario === "multimodal_audio") {
+    return { role: "assistant", content: "The mock chat model acknowledged the audio input." };
+  }
+
+  if (scenario === "file_reference") {
+    return { role: "assistant", content: "The mock chat model acknowledged the file input." };
+  }
+
+  if (scenario === "refusal") {
+    return { role: "assistant", content: "I cannot comply with this mock request." };
+  }
+
+  return { role: "assistant", content: "Hello from the mock OpenAI chat completion." };
+}
+
+function hasTools(request: ChatCompletionCreateRequest): boolean {
+  return toolNames(request).length > 0;
+}
+
+function hasMultipleTools(request: ChatCompletionCreateRequest): boolean {
+  return request.parallel_tool_calls === true && toolNames(request).length > 1;
+}
+
+function toolNames(request: ChatCompletionCreateRequest): string[] {
+  const toolNamesFromTools = (request.tools || [])
+    .map((tool) => tool.function?.name || tool.name)
+    .filter((name): name is string => Boolean(name));
+  const toolNamesFromFunctions = (request.functions || []).map((fn) => fn.name);
+
+  return [...toolNamesFromTools, ...toolNamesFromFunctions];
+}
+
+function toolArguments(name: string): Record<string, unknown> {
+  if (name.includes("weather")) {
+    return { city: "Tokyo" };
+  }
+
+  return { order_id: "A100" };
+}
+
+function hasToolResult(messages: ChatMessage[] | undefined): boolean {
+  return Boolean(messages?.some((message) => message.role === "tool" || message.role === "function"));
+}
+
+function extractToolResult(messages: ChatMessage[] | undefined): string {
+  const message = messages?.find((item) => item.role === "tool" || item.role === "function");
+  if (!message) {
+    return "{}";
+  }
+
+  return typeof message.content === "string" ? message.content : JSON.stringify(message.content || {});
+}
+
+function inferChatMultimodalScenario(messages: ChatMessage[]): ScenarioName | undefined {
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (part.type === "input_audio") {
+        return "multimodal_audio";
+      }
+
+      if (part.type === "file") {
+        return "file_reference";
+      }
+
+      if (part.type === "image_url") {
+        return "vision";
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function splitText(text: string): string[] {
+  const words = text.split(" ");
+  const chunks: string[] = [];
+
+  for (let index = 0; index < words.length; index += 4) {
+    chunks.push(words.slice(index, index + 4).join(" ") + (index + 4 < words.length ? " " : ""));
+  }
+
+  return chunks.length > 0 ? chunks : [text];
+}
+
+function getIdFactory(seed: string): IdFactory {
+  if (seed === "default") {
+    return processFactory;
+  }
+
+  const existing = seededFactories.get(seed);
+  if (existing) {
+    return existing;
+  }
+
+  const factory = new IdFactory(seed);
+  seededFactories.set(seed, factory);
+  return factory;
+}
+
+function openAIValidationError(issue: ValidationIssue): ProviderError {
+  if (issue.code === "missing_parameter") {
+    return {
+      status: 400,
+      body: {
+        error: {
+          message: issue.message,
+          type: "invalid_request_error",
+          code: "missing_parameter",
+        },
+      },
+    };
+  }
+
+  return buildOpenAIError(400, issue.message, issue.param || undefined);
+}

--- a/src/providers/openai/embeddings.routes.ts
+++ b/src/providers/openai/embeddings.routes.ts
@@ -1,0 +1,101 @@
+import { Request, RequestHandler, Response, Router } from "express";
+import { getInjectedProviderError } from "../../core/errors/errorInjector";
+import { buildOpenAIError, ProviderError } from "../../core/errors/providerErrors";
+import { estimateTokens } from "../../core/usage/tokenEstimator";
+import {
+  validateOpenAIEmbeddingsRequest,
+  ValidationIssue,
+} from "../../core/validation/openaiSchemas";
+
+export const openAIEmbeddingsRouter: Router = Router();
+
+openAIEmbeddingsRouter.post("/", handleCreateEmbedding as RequestHandler);
+
+type EmbeddingsRequest = {
+  model?: string;
+  input?: string | string[];
+  dimensions?: number;
+  encoding_format?: "float" | "base64";
+};
+
+function handleCreateEmbedding(req: Request, res: Response) {
+  const injectedError = getInjectedProviderError({
+    provider: "openai",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const body = req.body as EmbeddingsRequest;
+  const validationResult = validateOpenAIEmbeddingsRequest(body);
+  if (!validationResult.ok) {
+    return sendError(res, openAIValidationError(validationResult.issue));
+  }
+
+  const input = body.input as string | string[];
+  const inputs = Array.isArray(input) ? input : [input];
+  const dimensions = body.dimensions && body.dimensions > 0 ? Math.min(body.dimensions, 2048) : 8;
+
+  res.json({
+    object: "list",
+    data: inputs.map((input, index) => ({
+      object: "embedding",
+      embedding: formatEmbedding(buildEmbedding(input, dimensions), body.encoding_format),
+      index,
+    })),
+    model: body.model,
+    usage: {
+      prompt_tokens: estimateTokens(inputs),
+      total_tokens: estimateTokens(inputs),
+    },
+  });
+}
+
+function buildEmbedding(input: string, dimensions: number): number[] {
+  const seed = Array.from(input).reduce((sum, char) => sum + char.charCodeAt(0), 0);
+
+  return Array.from({ length: dimensions }, (_, index) => {
+    const value = ((seed + index * 31) % 2000) / 1000 - 1;
+    return Number(value.toFixed(6));
+  });
+}
+
+function formatEmbedding(embedding: number[], encodingFormat: EmbeddingsRequest["encoding_format"]) {
+  if (encodingFormat !== "base64") {
+    return embedding;
+  }
+
+  const buffer = Buffer.alloc(embedding.length * 4);
+  embedding.forEach((value, index) => {
+    buffer.writeFloatLE(value, index * 4);
+  });
+
+  return buffer.toString("base64");
+}
+
+function sendError(res: Response, error: ProviderError) {
+  res.status(error.status).json(error.body);
+}
+
+function openAIValidationError(issue: ValidationIssue): ProviderError {
+  if (issue.code === "missing_parameter") {
+    return {
+      status: 400,
+      body: {
+        error: {
+          message: issue.message,
+          type: "invalid_request_error",
+          param: issue.param || null,
+          code: "missing_parameter",
+        },
+      },
+    };
+  }
+
+  return buildOpenAIError(400, issue.message, issue.param || undefined);
+}
+
+export default openAIEmbeddingsRouter;

--- a/src/providers/openai/files.routes.ts
+++ b/src/providers/openai/files.routes.ts
@@ -1,0 +1,2 @@
+export { providerFilesRouter as openAIFilesRouter } from "../files.routes";
+export { default } from "../files.routes";

--- a/src/providers/openai/images.routes.ts
+++ b/src/providers/openai/images.routes.ts
@@ -1,0 +1,51 @@
+import { Request, RequestHandler, Response, Router } from "express";
+import multer from "multer";
+import { getInjectedProviderError } from "../../core/errors/errorInjector";
+import { ProviderError } from "../../core/errors/providerErrors";
+import { ImgData } from "../../data/base64Img";
+
+export const openAIImagesSupportRouter: Router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+openAIImagesSupportRouter.post("/edits", upload.any(), handleImageEdit as RequestHandler);
+openAIImagesSupportRouter.post("/variations", upload.any(), handleImageVariation as RequestHandler);
+
+function handleImageEdit(req: Request, res: Response) {
+  sendImageResponse(req, res, "A deterministic mock image edit.");
+}
+
+function handleImageVariation(req: Request, res: Response) {
+  sendImageResponse(req, res, "A deterministic mock image variation.");
+}
+
+function sendImageResponse(req: Request, res: Response, revisedPrompt: string) {
+  const injectedError = getInjectedProviderError({
+    provider: "openai",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const body = req.body as { n?: string | number; response_format?: string };
+  const n = Number(body.n || 1);
+  const count = Number.isFinite(n) && n > 0 ? Math.min(n, 10) : 1;
+  const responseFormat = body.response_format;
+
+  res.json({
+    created: Math.floor(Date.now() / 1000),
+    data: Array.from({ length: count }, () =>
+      responseFormat === "b64_json"
+        ? { b64_json: ImgData, revised_prompt: revisedPrompt }
+        : { url: ImgData, revised_prompt: revisedPrompt }
+    ),
+  });
+}
+
+function sendError(res: Response, error: ProviderError) {
+  res.status(error.status).json(error.body);
+}
+
+export default openAIImagesSupportRouter;

--- a/src/providers/openai/images.routes.ts
+++ b/src/providers/openai/images.routes.ts
@@ -5,7 +5,14 @@ import { ProviderError } from "../../core/errors/providerErrors";
 import { ImgData } from "../../data/base64Img";
 
 export const openAIImagesSupportRouter: Router = Router();
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    files: 2,
+    fileSize: 10 * 1024 * 1024,
+    fields: 20,
+  },
+});
 
 openAIImagesSupportRouter.post("/edits", upload.any(), handleImageEdit as RequestHandler);
 openAIImagesSupportRouter.post("/variations", upload.any(), handleImageVariation as RequestHandler);

--- a/src/providers/openai/models.routes.ts
+++ b/src/providers/openai/models.routes.ts
@@ -1,0 +1,9 @@
+import { RequestHandler, Router } from "express";
+import { handleGetModels } from "../../controllers/openaiController";
+
+export const openAIModelsRouter: Router = Router();
+export const handleListOpenAIModels = handleGetModels;
+
+openAIModelsRouter.get("/", handleListOpenAIModels as RequestHandler);
+
+export default openAIModelsRouter;

--- a/src/providers/openai/responses.routes.ts
+++ b/src/providers/openai/responses.routes.ts
@@ -1,0 +1,131 @@
+import { Request, RequestHandler, Response, Router } from "express";
+import { getInjectedProviderError } from "../../core/errors/errorInjector";
+import { ProviderError } from "../../core/errors/providerErrors";
+import { readMockStreamChunkDelay } from "../../core/http/mockControls";
+import { OPENAI_SSE_HEADERS } from "../../core/sse/openaiSse";
+import { sendEncodedSse } from "../../core/sse/streamWriter";
+import { selectScenario } from "../../core/scenarioEngine";
+import {
+  cancelOpenAIResponse,
+  compactOpenAIResponse,
+  countOpenAIResponseInputTokens,
+  createOpenAIResponse,
+  deleteOpenAIResponse,
+  encodeOpenAIResponseStream,
+  getOpenAIResponse,
+  listOpenAIResponseInputItems,
+  OpenAIResponseCreateRequest,
+  ServiceResult,
+} from "./responses.service";
+
+export const openAIResponsesRouter: Router = Router();
+
+openAIResponsesRouter.post("/input_tokens", handleInputTokens as RequestHandler);
+openAIResponsesRouter.post("/compact", handleCompact as RequestHandler);
+openAIResponsesRouter.post("/", handleCreateResponse as RequestHandler);
+openAIResponsesRouter.get("/:response_id/input_items", handleInputItems as RequestHandler);
+openAIResponsesRouter.post("/:response_id/cancel", handleCancelResponse as RequestHandler);
+openAIResponsesRouter.get("/:response_id", handleGetResponse as RequestHandler);
+openAIResponsesRouter.delete("/:response_id", handleDeleteResponse as RequestHandler);
+
+async function handleCreateResponse(req: Request, res: Response) {
+  const injectedError = getInjectedProviderError({
+    provider: "openai",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  const request = req.body as OpenAIResponseCreateRequest;
+  const selection = selectOpenAIScenario(req);
+  const result = createOpenAIResponse(request, selection);
+
+  if (!result.ok) {
+    return sendError(res, result.error);
+  }
+
+  if (request.stream) {
+    await sendEncodedSse(
+      res,
+      OPENAI_SSE_HEADERS,
+      encodeOpenAIResponseStream(result.value.response),
+      readMockStreamChunkDelay(req)
+    );
+    return;
+  }
+
+  res.json(result.value.response);
+}
+
+function handleGetResponse(req: Request, res: Response) {
+  sendResult(res, getOpenAIResponse(req.params.response_id));
+}
+
+function handleDeleteResponse(req: Request, res: Response) {
+  sendResult(res, deleteOpenAIResponse(req.params.response_id));
+}
+
+function handleCancelResponse(req: Request, res: Response) {
+  sendResult(res, cancelOpenAIResponse(req.params.response_id));
+}
+
+function handleInputItems(req: Request, res: Response) {
+  sendResult(res, listOpenAIResponseInputItems(req.params.response_id));
+}
+
+function handleInputTokens(req: Request, res: Response) {
+  const injectedError = getInjectedProviderError({
+    provider: "openai",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  res.json(countOpenAIResponseInputTokens(req.body));
+}
+
+function handleCompact(req: Request, res: Response) {
+  const injectedError = getInjectedProviderError({
+    provider: "openai",
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+  });
+
+  if (injectedError) {
+    return sendError(res, injectedError);
+  }
+
+  sendResult(res, compactOpenAIResponse(req.body as OpenAIResponseCreateRequest, selectOpenAIScenario(req)));
+}
+
+function selectOpenAIScenario(req: Request) {
+  return selectScenario({
+    provider: "openai",
+    endpoint: req.path,
+    method: req.method,
+    headers: req.headers,
+    query: req.query as Record<string, unknown>,
+    body: req.body,
+    model: typeof req.body?.model === "string" ? req.body.model : undefined,
+  });
+}
+
+function sendResult<T>(res: Response, result: ServiceResult<T>) {
+  if (!result.ok) {
+    return sendError(res, result.error);
+  }
+
+  res.json(result.value);
+}
+
+function sendError(res: Response, error: ProviderError) {
+  res.status(error.status).json(error.body);
+}
+
+export default openAIResponsesRouter;

--- a/src/providers/openai/responses.service.ts
+++ b/src/providers/openai/responses.service.ts
@@ -1,0 +1,591 @@
+import { buildOpenAIError, ProviderError } from "../../core/errors/providerErrors";
+import { IdFactory } from "../../core/state/idFactory";
+import { MemoryStateStore, MockStateRecord } from "../../core/state/memoryStore";
+import { ScenarioName, ScenarioSelection } from "../../core/scenarioEngine";
+import { openAIDone, openAIEvent } from "../../core/sse/openaiSse";
+import { estimateTokens } from "../../core/usage/tokenEstimator";
+import { buildOpenAIResponsesUsage, OpenAIResponsesUsage } from "../../core/usage/usageBuilder";
+import {
+  validateOpenAIResponsesRequest,
+  ValidationIssue,
+} from "../../core/validation/openaiSchemas";
+
+export type OpenAIResponseCreateRequest = {
+  model?: string;
+  input?: unknown;
+  instructions?: string;
+  previous_response_id?: string | null;
+  tools?: Array<Record<string, unknown>>;
+  tool_choice?: unknown;
+  parallel_tool_calls?: boolean;
+  reasoning?: Record<string, unknown> | null;
+  text?: Record<string, unknown>;
+  stream?: boolean;
+  store?: boolean;
+  background?: boolean;
+  metadata?: Record<string, string>;
+  include?: string[];
+};
+
+export type OpenAIResponseContent =
+  | { type: "output_text"; text: string; annotations: unknown[] }
+  | { type: "refusal"; refusal: string };
+
+export type OpenAIResponseOutputItem =
+  | {
+      id: string;
+      type: "message";
+      status: "completed" | "in_progress" | "incomplete";
+      role: "assistant";
+      content: OpenAIResponseContent[];
+    }
+  | {
+      id: string;
+      type: "function_call";
+      status: "completed";
+      call_id: string;
+      name: string;
+      arguments: string;
+    };
+
+export type OpenAIResponseObject = {
+  id: string;
+  object: "response";
+  created_at: number;
+  status: "completed" | "failed" | "in_progress" | "cancelled" | "queued" | "incomplete";
+  model: string;
+  output: OpenAIResponseOutputItem[];
+  usage?: OpenAIResponsesUsage;
+  tools?: Array<Record<string, unknown>>;
+  tool_choice?: unknown;
+  parallel_tool_calls?: boolean;
+  previous_response_id?: string | null;
+  reasoning?: Record<string, unknown> | null;
+  text?: Record<string, unknown>;
+  metadata?: Record<string, string>;
+  error?: Record<string, unknown> | null;
+  incomplete_details?: Record<string, unknown> | null;
+};
+
+export type OpenAIResponseRecord = MockStateRecord & {
+  response: OpenAIResponseObject;
+  input_items: unknown[];
+};
+
+export type ServiceResult<T> = { ok: true; value: T } | { ok: false; error: ProviderError };
+
+export const openAIResponsesStore = new MemoryStateStore();
+
+const seededFactories = new Map<string, IdFactory>();
+const processFactory = new IdFactory();
+
+export function createOpenAIResponse(
+  request: OpenAIResponseCreateRequest,
+  selection: ScenarioSelection
+): ServiceResult<{ response: OpenAIResponseObject; inputItems: unknown[]; shouldStore: boolean }> {
+  const validationResult = validateOpenAIResponsesRequest(request);
+  if (!validationResult.ok) {
+    return { ok: false, error: openAIValidationError(validationResult.issue) };
+  }
+
+  if (selection.scenario === "invalid_request") {
+    return { ok: false, error: buildOpenAIError(400, "Invalid mock request scenario.") };
+  }
+
+  if (selection.scenario === "rate_limit") {
+    return { ok: false, error: buildOpenAIError(429, "Mock rate limit exceeded.") };
+  }
+
+  if (selection.scenario === "invalid_tool_args") {
+    return { ok: false, error: buildOpenAIError(400, "Invalid mock tool arguments.", "tools") };
+  }
+
+  if (request.previous_response_id && !openAIResponsesStore.get("responses", request.previous_response_id)) {
+    return {
+      ok: false,
+      error: buildOpenAIError(404, `Response '${request.previous_response_id}' was not found.`),
+    };
+  }
+
+  const factory = getIdFactory(selection.seed);
+  const model = request.model || "gpt-4.1-mini";
+  const responseId = factory.next("response", "openai.responses");
+  const inputItems = normalizeInputItems(request.input, factory);
+  const output = buildOutputItems(request, selection.scenario, factory);
+  const status = statusForScenario(selection.scenario, request);
+  const outputText = extractOutputText(output);
+  const reasoningTokens = selection.scenario === "reasoning" || request.reasoning ? 8 : 0;
+  const usage = buildOpenAIResponsesUsage(request.input || request, outputText, reasoningTokens);
+
+  const response: OpenAIResponseObject = {
+    id: responseId,
+    object: "response",
+    created_at: Math.floor(Date.now() / 1000),
+    status,
+    model,
+    output,
+    usage,
+    tools: request.tools || [],
+    tool_choice: request.tool_choice || "auto",
+    parallel_tool_calls: request.parallel_tool_calls ?? true,
+    previous_response_id: request.previous_response_id || null,
+    reasoning: request.reasoning || (reasoningTokens > 0 ? { effort: "medium", summary: null } : null),
+    text: request.text || { format: { type: "text" } },
+    metadata: request.metadata || {},
+    error: selection.scenario === "failed" ? { code: "mock_failed", message: "Mock response failed." } : null,
+    incomplete_details: null,
+  };
+
+  const shouldStore = request.store !== false;
+  if (shouldStore) {
+    openAIResponsesStore.create<OpenAIResponseRecord>("responses", {
+      id: response.id,
+      provider: "openai",
+      response,
+      input_items: inputItems,
+    });
+  }
+
+  return { ok: true, value: { response, inputItems, shouldStore } };
+}
+
+export function getOpenAIResponse(responseId: string): ServiceResult<OpenAIResponseObject> {
+  const record = openAIResponsesStore.get<OpenAIResponseRecord>("responses", responseId);
+
+  if (!record) {
+    return { ok: false, error: buildOpenAIError(404, `Response '${responseId}' was not found.`) };
+  }
+
+  return { ok: true, value: record.response };
+}
+
+export function deleteOpenAIResponse(responseId: string): ServiceResult<{
+  id: string;
+  object: "response.deleted";
+  deleted: boolean;
+}> {
+  const deleted = openAIResponsesStore.delete("responses", responseId);
+
+  if (!deleted) {
+    return { ok: false, error: buildOpenAIError(404, `Response '${responseId}' was not found.`) };
+  }
+
+  return { ok: true, value: { id: responseId, object: "response.deleted", deleted: true } };
+}
+
+export function cancelOpenAIResponse(responseId: string): ServiceResult<OpenAIResponseObject> {
+  const record = openAIResponsesStore.get<OpenAIResponseRecord>("responses", responseId);
+
+  if (!record) {
+    return { ok: false, error: buildOpenAIError(404, `Response '${responseId}' was not found.`) };
+  }
+
+  if (record.response.status === "completed" || record.response.status === "failed") {
+    return {
+      ok: false,
+      error: buildOpenAIError(409, `Response '${responseId}' cannot be cancelled.`),
+    };
+  }
+
+  const updatedResponse: OpenAIResponseObject = {
+    ...record.response,
+    status: "cancelled",
+    error: null,
+  };
+
+  openAIResponsesStore.update<OpenAIResponseRecord>("responses", responseId, {
+    response: updatedResponse,
+  });
+
+  return { ok: true, value: updatedResponse };
+}
+
+export function listOpenAIResponseInputItems(responseId: string): ServiceResult<{
+  object: "list";
+  data: unknown[];
+  first_id: string | null;
+  last_id: string | null;
+  has_more: false;
+}> {
+  const record = openAIResponsesStore.get<OpenAIResponseRecord>("responses", responseId);
+
+  if (!record) {
+    return { ok: false, error: buildOpenAIError(404, `Response '${responseId}' was not found.`) };
+  }
+
+  const ids = record.input_items
+    .filter(isRecord)
+    .map((item) => (typeof item.id === "string" ? item.id : null))
+    .filter((id): id is string => Boolean(id));
+
+  return {
+    ok: true,
+    value: {
+      object: "list",
+      data: record.input_items,
+      first_id: ids[0] || null,
+      last_id: ids.at(-1) || null,
+      has_more: false,
+    },
+  };
+}
+
+export function countOpenAIResponseInputTokens(body: unknown): {
+  object: "response.input_tokens";
+  input_tokens: number;
+} {
+  return {
+    object: "response.input_tokens",
+    input_tokens: estimateTokens(isRecord(body) && "input" in body ? body.input : body),
+  };
+}
+
+export function compactOpenAIResponse(
+  body: OpenAIResponseCreateRequest,
+  selection: ScenarioSelection
+): ServiceResult<OpenAIResponseObject> {
+  const result = createOpenAIResponse(
+    {
+      ...body,
+      input: "Compacted conversation context for deterministic mock replay.",
+      store: false,
+    },
+    { ...selection, scenario: "simple_text" }
+  );
+
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    value: {
+      ...result.value.response,
+      output: [
+        buildMessageOutput(
+          getIdFactory(selection.seed),
+          "The prior conversation was compacted into a deterministic mock summary."
+        ),
+      ],
+    },
+  };
+}
+
+export function encodeOpenAIResponseStream(response: OpenAIResponseObject): string {
+  const message = response.output.find((item) => item.type === "message");
+  const messageId = message?.id || "msg_mock_stream_0001";
+  const text = message && message.type === "message" ? extractMessageText(message) : "";
+  const chunks = splitText(text || "Hello from the mock Responses API.");
+
+  const events = [
+    openAIEvent("response.created", {
+      type: "response.created",
+      response: { id: response.id, object: "response", status: "in_progress" },
+    }),
+    openAIEvent("response.in_progress", {
+      type: "response.in_progress",
+      response: { id: response.id, status: "in_progress" },
+    }),
+    openAIEvent("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: {
+        id: messageId,
+        type: "message",
+        status: "in_progress",
+        role: "assistant",
+        content: [],
+      },
+    }),
+    openAIEvent("response.content_part.added", {
+      type: "response.content_part.added",
+      item_id: messageId,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    }),
+    ...chunks.map((chunk) =>
+      openAIEvent("response.output_text.delta", {
+        type: "response.output_text.delta",
+        item_id: messageId,
+        output_index: 0,
+        content_index: 0,
+        delta: chunk,
+      })
+    ),
+    openAIEvent("response.output_text.done", {
+      type: "response.output_text.done",
+      item_id: messageId,
+      output_index: 0,
+      content_index: 0,
+      text,
+    }),
+    openAIEvent("response.content_part.done", {
+      type: "response.content_part.done",
+      item_id: messageId,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text, annotations: [] },
+    }),
+    openAIEvent("response.output_item.done", {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: message,
+    }),
+    openAIEvent(response.status === "failed" ? "response.failed" : "response.completed", {
+      type: response.status === "failed" ? "response.failed" : "response.completed",
+      response: { id: response.id, object: "response", status: response.status },
+    }),
+    openAIDone(),
+  ];
+
+  return events.join("");
+}
+
+function buildOutputItems(
+  request: OpenAIResponseCreateRequest,
+  scenario: ScenarioName,
+  factory: IdFactory
+): OpenAIResponseOutputItem[] {
+  if (scenario === "tool_call") {
+    return [buildFunctionCallOutput(factory, firstToolName(request.tools))];
+  }
+
+  if (scenario === "parallel_tools") {
+    const names = toolNames(request.tools);
+    const selectedNames = names.length > 1 ? names : ["get_order", "get_weather"];
+    return selectedNames.slice(0, 4).map((name) => buildFunctionCallOutput(factory, name));
+  }
+
+  if (scenario === "tool_result") {
+    return [
+      buildMessageOutput(
+        factory,
+        `The mock tool result was processed successfully: ${extractToolResultText(request.input)}`
+      ),
+    ];
+  }
+
+  if (scenario === "structured_json") {
+    return [buildMessageOutput(factory, '{"name":"UltraWidget","price":19.99,"currency":"USD"}')];
+  }
+
+  if (scenario === "refusal") {
+    return [
+      {
+        id: factory.next("message", "openai.responses.output"),
+        type: "message",
+        status: "completed",
+        role: "assistant",
+        content: [{ type: "refusal", refusal: "I cannot comply with this mock request." }],
+      },
+    ];
+  }
+
+  if (scenario === "failed" || scenario === "cancelled") {
+    return [];
+  }
+
+  return [
+    buildMessageOutput(
+      factory,
+      scenario === "reasoning"
+        ? "The mock response includes deterministic reasoning metadata."
+        : "The agent harness protocol upgrade is on track across all provider mocks."
+    ),
+  ];
+}
+
+function buildMessageOutput(factory: IdFactory, text: string): OpenAIResponseOutputItem {
+  return {
+    id: factory.next("message", "openai.responses.output"),
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text, annotations: [] }],
+  };
+}
+
+function buildFunctionCallOutput(factory: IdFactory, name: string): OpenAIResponseOutputItem {
+  return {
+    id: factory.next("functionCall", "openai.responses.output"),
+    type: "function_call",
+    status: "completed",
+    call_id: factory.next("call", `openai.responses.${name}`),
+    name,
+    arguments: JSON.stringify(buildToolArguments(name)),
+  };
+}
+
+function buildToolArguments(name: string): Record<string, unknown> {
+  if (name.includes("weather")) {
+    return { city: "Tokyo" };
+  }
+
+  if (name.includes("order")) {
+    return { order_id: "A100" };
+  }
+
+  return { query: "mock" };
+}
+
+function normalizeInputItems(input: unknown, factory: IdFactory): unknown[] {
+  if (Array.isArray(input)) {
+    return input.map((item) => addInputId(item, factory));
+  }
+
+  if (typeof input === "string") {
+    return [
+      {
+        id: factory.next("message", "openai.responses.input"),
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: input }],
+      },
+    ];
+  }
+
+  if (input && isRecord(input)) {
+    return [addInputId(input, factory)];
+  }
+
+  return [
+    {
+      id: factory.next("message", "openai.responses.input"),
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "Hello from the mock input." }],
+    },
+  ];
+}
+
+function addInputId(input: unknown, factory: IdFactory): unknown {
+  if (!isRecord(input) || typeof input.id === "string") {
+    return input;
+  }
+
+  return {
+    id: factory.next("message", "openai.responses.input"),
+    ...input,
+  };
+}
+
+function statusForScenario(
+  scenario: ScenarioName,
+  request: OpenAIResponseCreateRequest
+): OpenAIResponseObject["status"] {
+  if (scenario === "failed") {
+    return "failed";
+  }
+
+  if (scenario === "cancelled") {
+    return "cancelled";
+  }
+
+  if (scenario === "background" || request.background) {
+    return "queued";
+  }
+
+  return "completed";
+}
+
+function firstToolName(tools: Array<Record<string, unknown>> | undefined): string {
+  return toolNames(tools)[0] || "get_order";
+}
+
+function toolNames(tools: Array<Record<string, unknown>> | undefined): string[] {
+  if (!tools) {
+    return [];
+  }
+
+  return tools
+    .map((tool) => {
+      if (typeof tool.name === "string") {
+        return tool.name;
+      }
+
+      if (isRecord(tool.function) && typeof tool.function.name === "string") {
+        return tool.function.name;
+      }
+
+      return undefined;
+    })
+    .filter((name): name is string => Boolean(name));
+}
+
+function extractToolResultText(input: unknown): string {
+  const results: string[] = [];
+
+  visit(input, (value) => {
+    if (!isRecord(value)) {
+      return;
+    }
+
+    if (typeof value.output === "string") {
+      results.push(value.output);
+    }
+
+    if (typeof value.content === "string" && value.type === "tool_result") {
+      results.push(value.content);
+    }
+  });
+
+  return results[0] || "{}";
+}
+
+function extractOutputText(output: OpenAIResponseOutputItem[]): string {
+  return output.map((item) => (item.type === "message" ? extractMessageText(item) : item.arguments)).join(" ");
+}
+
+function extractMessageText(message: Extract<OpenAIResponseOutputItem, { type: "message" }>): string {
+  return message.content
+    .map((content) => ("text" in content ? content.text : content.refusal))
+    .join(" ");
+}
+
+function splitText(text: string): string[] {
+  const words = text.split(" ");
+  const chunks: string[] = [];
+
+  for (let index = 0; index < words.length; index += 4) {
+    chunks.push(words.slice(index, index + 4).join(" ") + (index + 4 < words.length ? " " : ""));
+  }
+
+  return chunks.length > 0 ? chunks : [text];
+}
+
+function getIdFactory(seed: string): IdFactory {
+  if (seed === "default") {
+    return processFactory;
+  }
+
+  const existing = seededFactories.get(seed);
+  if (existing) {
+    return existing;
+  }
+
+  const factory = new IdFactory(seed);
+  seededFactories.set(seed, factory);
+  return factory;
+}
+
+function openAIValidationError(issue: ValidationIssue): ProviderError {
+  return buildOpenAIError(400, issue.message, issue.param || undefined);
+}
+
+function visit(value: unknown, visitor: (value: unknown) => void): void {
+  visitor(value);
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => visit(item, visitor));
+    return;
+  }
+
+  if (isRecord(value)) {
+    Object.values(value).forEach((item) => visit(item, visitor));
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/providers/openai/responses.service.ts
+++ b/src/providers/openai/responses.service.ts
@@ -273,9 +273,23 @@ export function compactOpenAIResponse(
 
 export function encodeOpenAIResponseStream(response: OpenAIResponseObject): string {
   const message = response.output.find((item) => item.type === "message");
-  const messageId = message?.id || "msg_mock_stream_0001";
-  const text = message && message.type === "message" ? extractMessageText(message) : "";
-  const chunks = splitText(text || "Hello from the mock Responses API.");
+  if (!message) {
+    const terminalEvents = [
+      openAIEvent("response.created", {
+        type: "response.created",
+        response: { id: response.id, object: "response", status: "in_progress" },
+      }),
+      openAIEvent(response.status === "failed" ? "response.failed" : "response.completed", {
+        type: response.status === "failed" ? "response.failed" : "response.completed",
+        response: { id: response.id, object: "response", status: response.status },
+      }),
+      openAIDone(),
+    ];
+    return terminalEvents.join("");
+  }
+  const messageId = message.id;
+  const text = extractMessageText(message);
+  const chunks = splitText(text);
 
   const events = [
     openAIEvent("response.created", {
@@ -465,8 +479,8 @@ function addInputId(input: unknown, factory: IdFactory): unknown {
   }
 
   return {
-    id: factory.next("message", "openai.responses.input"),
     ...input,
+    id: factory.next("message", "openai.responses.input"),
   };
 }
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,18 +1,27 @@
-import { Router, RequestHandler } from "express";
+import { Router, Request, RequestHandler, Response } from "express";
 import {
   handleGetModels,
-  handleChatCompletion,
   handleImageGeneration,
   handleHealthCheck,
 } from "../controllers/openaiController";
-import {
-  handleGetModels as handleGetAnthropicModels,
-  handleMessage as handleAnthropicMessage,
-} from "../controllers/anthropicController";
-import {
-  handleGetGeminiModels,
-  handleGenerateContent,
-} from "../controllers/geminiController";
+import anthropicMessagesRouter, {
+  handleCreateMessage as handleAnthropicMessage,
+} from "../providers/anthropic/messages.routes";
+import { handleListAnthropicModels } from "../providers/anthropic/models.routes";
+import providerFilesRouter from "../providers/files.routes";
+import geminiCachedContentsRouter from "../providers/gemini/cachedContents.routes";
+import geminiFilesRouter from "../providers/gemini/files.routes";
+import geminiGenerateContentRouter, {
+  handleGenerateContent as handleGeminiGenerateContent,
+} from "../providers/gemini/generateContent.routes";
+import geminiTokensRouter from "../providers/gemini/tokens.routes";
+import { handleListGeminiModels } from "../providers/gemini/models.routes";
+import openAIChatRouter, {
+  handleCreateChatCompletion,
+} from "../providers/openai/chat.routes";
+import openAIEmbeddingsRouter from "../providers/openai/embeddings.routes";
+import openAIImagesSupportRouter from "../providers/openai/images.routes";
+import openAIResponsesRouter from "../providers/openai/responses.routes";
 
 const router: Router = Router();
 
@@ -30,28 +39,50 @@ router.use((req, res, next) => {
 router.get("/health", handleHealthCheck as RequestHandler);
 
 // OpenAI API compatible endpoints
-router.get("/v1/models", handleGetModels as RequestHandler);
+router.get("/v1/models", handleProviderModels as RequestHandler);
 router.get("/models", handleGetModels as RequestHandler);
-router.post("/v1/chat/completions", handleChatCompletion as RequestHandler);
-router.post("/chat/completions", handleChatCompletion as RequestHandler);
+router.use("/v1/responses", openAIResponsesRouter);
+router.use("/v1/embeddings", openAIEmbeddingsRouter);
+router.use("/v1/files", providerFilesRouter);
+router.use("/v1/chat/completions", openAIChatRouter);
+router.post("/chat/completions", handleCreateChatCompletion as RequestHandler);
 
 // Anthropic API compatible endpoints
 console.log('🔧 [Router] Registering Anthropic routes...');
-router.get("/anthropic/v1/models", handleGetAnthropicModels as RequestHandler);
+router.use("/v1/messages", anthropicMessagesRouter);
+router.get("/anthropic/v1/models", handleListAnthropicModels as RequestHandler);
 router.post("/anthropic/v1/messages", handleAnthropicMessage as RequestHandler);
 console.log('✅ [Router] Anthropic routes registered successfully');
 
 // Gemini API compatible endpoints (matching Google's official format)
-router.get("/v1beta/models", handleGetGeminiModels as RequestHandler);
-router.post("/v1beta/models/:model\\:generateContent", handleGenerateContent as RequestHandler);
-router.post("/v1beta/models/:model\\:streamGenerateContent", handleGenerateContent as RequestHandler);
+router.get("/v1beta/models", handleListGeminiModels as RequestHandler);
+router.use("/v1beta/models", geminiTokensRouter);
+router.use("/v1beta/models", geminiGenerateContentRouter);
 // Legacy routes for backward compatibility
-router.get("/gemini/v1/models", handleGetGeminiModels as RequestHandler);
-router.post("/gemini/v1/models/:model/generateContent", handleGenerateContent as RequestHandler);
-router.post("/gemini/v1/models/:model/streamGenerateContent", handleGenerateContent as RequestHandler);
+router.get("/gemini/v1/models", handleListGeminiModels as RequestHandler);
+router.post("/gemini/v1/models/:model/generateContent", handleGeminiGenerateContent as RequestHandler);
+router.post("/gemini/v1/models/:model/streamGenerateContent", handleGeminiGenerateContent as RequestHandler);
 
 // Compatible endpoints for different versions
 router.post("/v1/images/generations", handleImageGeneration as RequestHandler);
+router.use("/v1/images", openAIImagesSupportRouter);
 router.post("/images/generations", handleImageGeneration as RequestHandler);
+
+router.use("/", geminiFilesRouter);
+router.use("/", geminiCachedContentsRouter);
+
+function handleProviderModels(req: Request, res: Response) {
+  const provider = String(req.header("x-provider") || req.query.provider || "").toLowerCase();
+
+  if (provider === "anthropic" || req.header("anthropic-version")) {
+    return handleListAnthropicModels(req, res);
+  }
+
+  if (provider === "gemini" || provider === "google") {
+    return handleListGeminiModels(req, res);
+  }
+
+  return handleGetModels(req, res);
+}
 
 export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -48,11 +48,15 @@ router.use("/v1/chat/completions", openAIChatRouter);
 router.post("/chat/completions", handleCreateChatCompletion as RequestHandler);
 
 // Anthropic API compatible endpoints
-console.log('🔧 [Router] Registering Anthropic routes...');
+if (global.verboseLogging) {
+  console.log('🔧 [Router] Registering Anthropic routes...');
+}
 router.use("/v1/messages", anthropicMessagesRouter);
 router.get("/anthropic/v1/models", handleListAnthropicModels as RequestHandler);
 router.post("/anthropic/v1/messages", handleAnthropicMessage as RequestHandler);
-console.log('✅ [Router] Anthropic routes registered successfully');
+if (global.verboseLogging) {
+  console.log('✅ [Router] Anthropic routes registered successfully');
+}
 
 // Gemini API compatible endpoints (matching Google's official format)
 router.get("/v1beta/models", handleListGeminiModels as RequestHandler);

--- a/src/services/openaiService.ts
+++ b/src/services/openaiService.ts
@@ -841,7 +841,6 @@ export function generateImage(
 ): ImageGenerationResponse {
   const n = request.n || 1;
   const timestamp = getCurrentTimestamp();
-  const size = request.size || "1024x1024";
 
   // Choose different images based on model
   const model = request.model || "gpt-4o-image";

--- a/test/contract/anthropicMessages.test.ts
+++ b/test/contract/anthropicMessages.test.ts
@@ -1,0 +1,329 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import app from "../../src/app";
+import { collectSse, parseSseEvents } from "./helpers";
+
+const baseRequest = {
+  model: "claude-sonnet-4-5",
+  max_tokens: 256,
+  messages: [{ role: "user", content: "Hello" }],
+};
+
+describe("Anthropic Messages API contract", () => {
+  it.each(["/v1/messages", "/anthropic/v1/messages"])(
+    "creates simple text messages from %s",
+    async (path) => {
+      const response = await request(app).post(path).send(baseRequest).expect(200);
+
+      expect(response.body).toMatchObject({
+        id: expect.stringMatching(/^msg_mock_/),
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-5",
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        content: [expect.objectContaining({ type: "text", text: expect.any(String) })],
+        usage: {
+          input_tokens: expect.any(Number),
+          output_tokens: expect.any(Number),
+        },
+      });
+    }
+  );
+
+  it("returns tool_use blocks and stop_reason=tool_use when tools are present", async () => {
+    const response = await request(app)
+      .post("/v1/messages")
+      .send({
+        ...baseRequest,
+        messages: [{ role: "user", content: "Look up order A100." }],
+        tools: [
+          {
+            name: "get_order",
+            input_schema: {
+              type: "object",
+              properties: { order_id: { type: "string" } },
+            },
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(response.body.stop_reason).toBe("tool_use");
+    expect(response.body.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "tool_use",
+          id: expect.stringMatching(/^toolu_mock_/),
+          name: "get_order",
+          input: { order_id: "A100" },
+        }),
+      ])
+    );
+  });
+
+  it("returns multiple tool_use blocks for parallel tool scenarios", async () => {
+    const response = await request(app)
+      .post("/v1/messages")
+      .set("x-mock-scenario", "parallel_tools")
+      .send({
+        ...baseRequest,
+        tools: [
+          { name: "get_order", input_schema: { type: "object" } },
+          { name: "get_weather", input_schema: { type: "object" } },
+        ],
+      })
+      .expect(200);
+
+    expect(response.body.stop_reason).toBe("tool_use");
+    expect(response.body.content).toHaveLength(2);
+    expect(response.body.content.map((block: { name: string }) => block.name)).toEqual([
+      "get_order",
+      "get_weather",
+    ]);
+  });
+
+  it("returns final text for tool_result follow-up messages", async () => {
+    const response = await request(app)
+      .post("/v1/messages")
+      .send({
+        ...baseRequest,
+        messages: [
+          { role: "user", content: "Look up order A100." },
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "I'll check the requested information." },
+              {
+                type: "tool_use",
+                id: "toolu_mock_0001",
+                name: "get_order",
+                input: { order_id: "A100" },
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_mock_0001",
+                content: '{"status":"out_for_delivery","eta":"today by 18:00"}',
+              },
+            ],
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(response.body.stop_reason).toBe("end_turn");
+    expect(response.body.content[0].text).toContain("out_for_delivery");
+  });
+
+  it("supports extended thinking blocks and thinking stream deltas", async () => {
+    const response = await request(app)
+      .post("/v1/messages")
+      .send({
+        ...baseRequest,
+        thinking: { type: "enabled", budget_tokens: 1024 },
+      })
+      .expect(200);
+
+    expect(response.body.content[0]).toMatchObject({
+      type: "thinking",
+      thinking: expect.any(String),
+      signature: expect.stringMatching(/^msg_mock_/),
+    });
+
+    const stream = await collectSse(
+      request(app)
+        .post("/v1/messages")
+        .send({
+          ...baseRequest,
+          stream: true,
+          thinking: { type: "enabled", budget_tokens: 1024 },
+        })
+        .expect("Content-Type", /text\/event-stream/)
+        .expect(200)
+    );
+    const events = parseSseEvents(stream.body);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "content_block_delta",
+          data: expect.objectContaining({
+            delta: expect.objectContaining({ type: "thinking_delta" }),
+          }),
+        }),
+        expect.objectContaining({
+          event: "content_block_delta",
+          data: expect.objectContaining({
+            delta: expect.objectContaining({ type: "signature_delta" }),
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("supports refusal, max_tokens, pause_turn, and file reference scenarios", async () => {
+    const refusal = await request(app)
+      .post("/v1/messages")
+      .set("x-mock-scenario", "refusal")
+      .send(baseRequest)
+      .expect(200);
+    expect(refusal.body.stop_reason).toBe("refusal");
+
+    const maxTokens = await request(app)
+      .post("/v1/messages")
+      .send({ ...baseRequest, max_tokens: 1 })
+      .expect(200);
+    expect(maxTokens.body.stop_reason).toBe("max_tokens");
+
+    const pauseTurn = await request(app)
+      .post("/v1/messages")
+      .set("x-mock-scenario", "pause_turn")
+      .send(baseRequest)
+      .expect(200);
+    expect(pauseTurn.body.stop_reason).toBe("pause_turn");
+
+    const fileReference = await request(app)
+      .post("/v1/messages")
+      .send({
+        ...baseRequest,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "document",
+                source: { type: "file", file_id: "file_mock_0001" },
+                title: "policy.pdf",
+              },
+              { type: "text", text: "Summarize this document." },
+            ],
+          },
+        ],
+      })
+      .expect(200);
+    expect(fileReference.body.content[0].text).toContain("file reference");
+  });
+
+  it("streams text events in Anthropic order with content_block_stop", async () => {
+    const response = await collectSse(
+      request(app)
+        .post("/v1/messages")
+        .send({ ...baseRequest, stream: true })
+        .expect("Content-Type", /text\/event-stream/)
+        .expect(200)
+    );
+
+    const events = parseSseEvents(response.body);
+    expect(events.map((event) => event.event)).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+    expect(events.at(-1)).toMatchObject({ event: "message_stop", data: { type: "message_stop" } });
+  });
+
+  it("streams tool input JSON deltas that parse into valid arguments", async () => {
+    const response = await collectSse(
+      request(app)
+        .post("/v1/messages")
+        .send({
+          ...baseRequest,
+          stream: true,
+          tools: [{ name: "get_order", input_schema: { type: "object" } }],
+        })
+        .expect("Content-Type", /text\/event-stream/)
+        .expect(200)
+    );
+
+    const events = parseSseEvents(response.body);
+    const partialJson = events
+      .map((event) => event.data?.delta)
+      .filter((delta) => delta?.type === "input_json_delta")
+      .map((delta) => delta.partial_json)
+      .join("");
+
+    expect(JSON.parse(partialJson)).toEqual({ order_id: "A100" });
+  });
+
+  it("counts message tokens deterministically", async () => {
+    const response = await request(app)
+      .post("/v1/messages/count_tokens")
+      .send({
+        model: "claude-sonnet-4-5",
+        system: "You are concise.",
+        messages: [{ role: "user", content: "Hello" }],
+        tools: [{ name: "get_order", input_schema: { type: "object" } }],
+      })
+      .expect(200);
+
+    expect(response.body.input_tokens).toEqual(expect.any(Number));
+    expect(response.body.input_tokens).toBeGreaterThan(0);
+  });
+
+  it("returns Anthropic-style validation and injected errors", async () => {
+    const validation = await request(app)
+      .post("/v1/messages")
+      .send({ model: "claude-sonnet-4-5", max_tokens: 256, messages: [{ role: "developer", content: "No" }] })
+      .expect(400);
+    expect(validation.body).toEqual({
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: "messages contains an invalid role",
+      },
+    });
+
+    const rateLimit = await request(app)
+      .post("/v1/messages")
+      .set("x-mock-error", "429")
+      .send(baseRequest)
+      .expect(429);
+    expect(rateLimit.body.error.type).toBe("rate_limit_error");
+
+    const overloaded = await request(app)
+      .post("/v1/messages?mock_error=529")
+      .send(baseRequest)
+      .expect(529);
+    expect(overloaded.body.error.type).toBe("overloaded_error");
+
+    const invalidToolArgs = await request(app)
+      .post("/v1/messages")
+      .set("x-mock-scenario", "invalid_tool_args")
+      .send(baseRequest)
+      .expect(400);
+    expect(invalidToolArgs.body).toEqual({
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: "Invalid mock tool arguments.",
+      },
+    });
+  });
+
+  it("rejects invalid Anthropic content blocks with provider error shape", async () => {
+    const response = await request(app)
+      .post("/v1/messages")
+      .send({
+        model: "claude-sonnet-4-5",
+        max_tokens: 256,
+        messages: [{ role: "user", content: [{ type: "document" }] }],
+      })
+      .expect(400);
+
+    expect(response.body).toEqual({
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: "document block requires source",
+      },
+    });
+  });
+});

--- a/test/contract/baseline.test.ts
+++ b/test/contract/baseline.test.ts
@@ -1,0 +1,340 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import app from "../../src/app";
+import { collectSse, parseSseEvents } from "./helpers";
+
+const openAiChatRequest = {
+  model: "mock-gpt-thinking",
+  messages: [{ role: "user", content: "Hello" }],
+};
+
+const anthropicMessageRequest = {
+  model: "mock-claude-markdown",
+  max_tokens: 256,
+  messages: [{ role: "user", content: "Hello" }],
+};
+
+const geminiGenerateRequest = {
+  contents: [
+    {
+      role: "user",
+      parts: [{ text: "Hello" }],
+    },
+  ],
+};
+
+describe("legacy baseline contract", () => {
+  it("returns health status without provider credentials", async () => {
+    const response = await request(app).get("/health").expect(200);
+
+    expect(response.body).toMatchObject({
+      status: "ok",
+      message: "Mock OpenAI API server is running",
+      version: expect.any(String),
+    });
+    expect(response.body.timestamp).toEqual(expect.any(String));
+  });
+
+  it("returns a current endpoint summary from the root endpoint", async () => {
+    const response = await request(app).get("/").expect(200);
+
+    expect(response.body.availableEndpoints).toEqual(
+      expect.arrayContaining([
+        "POST /v1/responses",
+        "POST /v1/messages/count_tokens",
+        "POST /upload/v1beta/files",
+        "POST /v1beta/cachedContents",
+      ])
+    );
+  });
+
+  it.each(["/v1/models", "/models"])("returns OpenAI model list from %s", async (path) => {
+    const response = await request(app).get(path).expect(200);
+
+    expect(response.body.object).toBe("list");
+    expect(response.body.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "mock-gpt-thinking",
+          object: "model",
+          owned_by: "mock-openai",
+          created: expect.any(Number),
+        }),
+      ])
+    );
+  });
+
+  it("returns Anthropic and Gemini model shapes from /v1/models when provider is explicit", async () => {
+    const anthropic = await request(app)
+      .get("/v1/models")
+      .set("anthropic-version", "2023-06-01")
+      .expect(200);
+    expect(anthropic.body).toMatchObject({
+      data: expect.arrayContaining([
+        expect.objectContaining({ id: "mock-claude-markdown", type: "model" }),
+      ]),
+      has_more: false,
+    });
+
+    const gemini = await request(app).get("/v1/models?provider=gemini").expect(200);
+    expect(gemini.body.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "models/gemini-1.5-flash" }),
+      ])
+    );
+  });
+
+  it.each(["/v1/chat/completions", "/chat/completions"])(
+    "creates an OpenAI chat completion from %s",
+    async (path) => {
+      const response = await request(app).post(path).send(openAiChatRequest).expect(200);
+
+      expect(response.body).toMatchObject({
+        id: expect.stringMatching(/^chatcmpl(?:-|_mock_)/),
+        object: "chat.completion",
+        created: expect.any(Number),
+        model: openAiChatRequest.model,
+        choices: [
+          expect.objectContaining({
+            index: 0,
+            finish_reason: "stop",
+            message: expect.objectContaining({
+              role: "assistant",
+              content: expect.any(String),
+            }),
+          }),
+        ],
+        usage: expect.objectContaining({
+          prompt_tokens: expect.any(Number),
+          completion_tokens: expect.any(Number),
+          total_tokens: expect.any(Number),
+        }),
+      });
+    }
+  );
+
+  it("streams OpenAI chat completion chunks and terminates with DONE", async () => {
+    const response = await collectSse(
+      request(app)
+        .post("/v1/chat/completions")
+        .send({ ...openAiChatRequest, stream: true })
+        .expect("Content-Type", /text\/event-stream/)
+        .expect(200)
+    );
+
+    const events = parseSseEvents(response.body);
+    expect(events.at(-1)?.data).toBe("[DONE]");
+    expect(events[0].data).toMatchObject({
+      object: "chat.completion.chunk",
+      choices: [expect.objectContaining({ delta: expect.objectContaining({ role: "assistant" }) })],
+    });
+  });
+
+  it.each(["/v1/images/generations", "/images/generations"])(
+    "creates OpenAI image generation data from %s",
+    async (path) => {
+      const response = await request(app)
+        .post(path)
+        .send({
+          model: "gpt-4o-image",
+          prompt: "A cute orange cat",
+          n: 2,
+          size: "1024x1024",
+        })
+        .expect(200);
+
+      expect(response.body.created).toEqual(expect.any(Number));
+      expect(response.body.data).toHaveLength(2);
+      expect(response.body.data[0]).toEqual(
+        expect.objectContaining({
+          url: expect.any(String),
+        })
+      );
+    }
+  );
+
+  it("returns OpenAI validation errors with provider shape", async () => {
+    const response = await request(app)
+      .post("/v1/chat/completions")
+      .send({ messages: [{ role: "user", content: "Hello" }] })
+      .expect(400);
+
+    expect(response.body).toEqual({
+      error: {
+        message: "Missing required parameter: model",
+        type: "invalid_request_error",
+        code: "missing_parameter",
+      },
+    });
+  });
+
+  it("returns image validation errors with provider shape", async () => {
+    const response = await request(app).post("/v1/images/generations").send({}).expect(400);
+
+    expect(response.body.error).toMatchObject({
+      message: "Missing required parameter: prompt",
+      type: "invalid_request_error",
+      code: "missing_parameter",
+    });
+  });
+
+  it("returns Anthropic model list from the preserved alias", async () => {
+    const response = await request(app).get("/anthropic/v1/models").expect(200);
+
+    expect(response.body).toMatchObject({
+      first_id: "mock-claude-markdown",
+      last_id: "mock-claude-markdown",
+      has_more: false,
+    });
+    expect(response.body.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "mock-claude-markdown",
+          type: "model",
+          display_name: expect.any(String),
+        }),
+      ])
+    );
+  });
+
+  it("creates Anthropic message responses from the preserved alias", async () => {
+    const response = await request(app)
+      .post("/anthropic/v1/messages")
+      .send(anthropicMessageRequest)
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      id: expect.stringMatching(/^msg_/),
+      type: "message",
+      role: "assistant",
+      model: anthropicMessageRequest.model,
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      content: [expect.objectContaining({ type: "text", text: expect.any(String) })],
+      usage: expect.objectContaining({
+        input_tokens: expect.any(Number),
+        output_tokens: expect.any(Number),
+      }),
+    });
+  });
+
+  it("streams Anthropic message events from the preserved alias", async () => {
+    const response = await collectSse(
+      request(app)
+        .post("/anthropic/v1/messages")
+        .send({ ...anthropicMessageRequest, stream: true })
+        .expect("Content-Type", /text\/event-stream/)
+        .expect(200)
+    );
+
+    const events = parseSseEvents(response.body);
+    expect(events.map((event) => event.event)).toContain("message_start");
+    expect(events.map((event) => event.event)).toContain("content_block_delta");
+    expect(events.at(-1)).toMatchObject({ event: "message_stop", data: { type: "message_stop" } });
+  });
+
+  it("returns Anthropic validation errors with provider shape", async () => {
+    const response = await request(app)
+      .post("/anthropic/v1/messages")
+      .send({ model: "mock-claude-markdown" })
+      .expect(400);
+
+    expect(response.body).toEqual({
+      error: {
+        message: "Missing required fields: model, messages, or max_tokens",
+        type: "invalid_request_error",
+      },
+      type: "error",
+    });
+  });
+
+  it.each(["/v1beta/models", "/gemini/v1/models"])(
+    "returns Gemini model list from %s",
+    async (path) => {
+      const response = await request(app).get(path).expect(200);
+
+      expect(response.body.models).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "models/gemini-1.5-flash",
+            supportedGenerationMethods: expect.arrayContaining([
+              "generateContent",
+              "streamGenerateContent",
+            ]),
+          }),
+        ])
+      );
+    }
+  );
+
+  it.each([
+    "/v1beta/models/gemini-1.5-flash:generateContent",
+    "/gemini/v1/models/gemini-1.5-flash/generateContent",
+  ])("generates Gemini content from %s", async (path) => {
+    const response = await request(app).post(path).send(geminiGenerateRequest).expect(200);
+
+    expect(response.body).toMatchObject({
+      candidates: [
+        expect.objectContaining({
+          content: expect.objectContaining({
+            role: "model",
+            parts: [expect.objectContaining({ text: expect.any(String) })],
+          }),
+          finishReason: "STOP",
+          index: 0,
+        }),
+      ],
+      usageMetadata: expect.objectContaining({
+        promptTokenCount: expect.any(Number),
+        candidatesTokenCount: expect.any(Number),
+        totalTokenCount: expect.any(Number),
+      }),
+    });
+  });
+
+  it.each([
+    "/v1beta/models/gemini-1.5-flash:streamGenerateContent",
+    "/gemini/v1/models/gemini-1.5-flash/streamGenerateContent",
+  ])("streams Gemini content from %s", async (path) => {
+    const response = await collectSse(
+      request(app)
+        .post(path)
+        .send(geminiGenerateRequest)
+        .expect("Content-Type", /text\/event-stream/)
+        .expect(200)
+    );
+
+    const events = parseSseEvents(response.body);
+    expect(events.at(-1)?.data).toMatchObject({
+      candidates: [
+        expect.objectContaining({
+          finishReason: "STOP",
+        }),
+      ],
+    });
+    expect(events[0].data).toMatchObject({
+      candidates: [
+        expect.objectContaining({
+          content: expect.objectContaining({
+            parts: [expect.objectContaining({ text: expect.any(String) })],
+          }),
+        }),
+      ],
+    });
+  });
+
+  it("returns Gemini validation errors with provider shape", async () => {
+    const response = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .send({})
+      .expect(400);
+
+    expect(response.body).toEqual({
+      error: {
+        code: 400,
+        message: "Request must contain at least one content item",
+        status: "INVALID_ARGUMENT",
+      },
+    });
+  });
+});

--- a/test/contract/geminiGenerateContent.test.ts
+++ b/test/contract/geminiGenerateContent.test.ts
@@ -1,0 +1,363 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import app from "../../src/app";
+import { collectSse, parseSseEvents } from "./helpers";
+
+const baseRequest = {
+  contents: [
+    {
+      role: "user",
+      parts: [{ text: "Hello" }],
+    },
+  ],
+};
+
+describe("Gemini GenerateContent API contract", () => {
+  it("returns functionCall parts when function declarations are present", async () => {
+    const response = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .send({
+        ...baseRequest,
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: "get_order",
+                parameters: { type: "OBJECT" },
+              },
+            ],
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(response.body.candidates[0].content.parts).toEqual([
+      {
+        functionCall: {
+          id: expect.stringMatching(/^fc_mock_/),
+          name: "get_order",
+          args: { order_id: "A100" },
+        },
+      },
+    ]);
+  });
+
+  it("returns multiple functionCall parts for parallel functions", async () => {
+    const response = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .set("x-mock-scenario", "parallel_tools")
+      .send({
+        ...baseRequest,
+        tools: [
+          {
+            functionDeclarations: [
+              { name: "get_order", parameters: { type: "OBJECT" } },
+              { name: "get_weather", parameters: { type: "OBJECT" } },
+            ],
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(response.body.candidates[0].content.parts.map((part: { functionCall: { name: string } }) => part.functionCall.name)).toEqual([
+      "get_order",
+      "get_weather",
+    ]);
+  });
+
+  it("returns final text for functionResponse follow-ups", async () => {
+    const response = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .send({
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Get the delivery status for order A100." }],
+          },
+          {
+            role: "model",
+            parts: [
+              {
+                functionCall: {
+                  id: "fc_mock_0001",
+                  name: "get_order",
+                  args: { order_id: "A100" },
+                },
+              },
+            ],
+          },
+          {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  id: "fc_mock_0001",
+                  name: "get_order",
+                  response: { status: "out_for_delivery", eta: "today by 18:00" },
+                },
+              },
+            ],
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(response.body.candidates[0].content.parts[0].text).toContain("out_for_delivery");
+  });
+
+  it("rejects functionResponse IDs that do not match a previous functionCall ID", async () => {
+    const response = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .send({
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Get the delivery status for order A100." }],
+          },
+          {
+            role: "model",
+            parts: [
+              {
+                functionCall: {
+                  id: "fc_mock_0001",
+                  name: "get_order",
+                  args: { order_id: "A100" },
+                },
+              },
+            ],
+          },
+          {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  id: "fc_mock_other",
+                  name: "get_order",
+                  response: { status: "out_for_delivery" },
+                },
+              },
+            ],
+          },
+        ],
+      })
+      .expect(400);
+
+    expect(response.body.error).toMatchObject({
+      status: "INVALID_ARGUMENT",
+      message: "functionResponse id does not match a previous functionCall id",
+    });
+  });
+
+  it("returns structured JSON and enum-compatible text", async () => {
+    const json = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .send({
+        ...baseRequest,
+        generationConfig: {
+          responseMimeType: "application/json",
+          responseSchema: { type: "OBJECT" },
+        },
+      })
+      .expect(200);
+    expect(JSON.parse(json.body.candidates[0].content.parts[0].text)).toEqual({
+      name: "UltraWidget",
+      price: 19.99,
+      currency: "USD",
+    });
+
+    const enumResponse = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .send({
+        ...baseRequest,
+        generationConfig: {
+          responseMimeType: "text/x.enum",
+          responseSchema: { type: "STRING", enum: ["positive", "negative", "neutral"] },
+        },
+      })
+      .expect(200);
+    expect(enumResponse.body.candidates[0].content.parts[0].text).toBe("positive");
+  });
+
+  it("returns safety block metadata for safety scenarios", async () => {
+    const response = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .set("x-mock-scenario", "safety_block")
+      .send(baseRequest)
+      .expect(200);
+
+    expect(response.body.promptFeedback).toMatchObject({ blockReason: "SAFETY" });
+    expect(response.body.candidates[0].finishReason).toBe("SAFETY");
+  });
+
+  it("supports code execution and Google Search tool mocks", async () => {
+    const codeExecution = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .send({
+        ...baseRequest,
+        tools: [{ codeExecution: {} }],
+      })
+      .expect(200);
+    expect(codeExecution.body.candidates[0].content.parts).toEqual([
+      { executableCode: { language: "PYTHON", code: 'print("mock code execution")' } },
+      { codeExecutionResult: { outcome: "OUTCOME_OK", output: "mock code execution\n" } },
+    ]);
+
+    const search = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .send({
+        ...baseRequest,
+        tools: [{ googleSearch: {} }],
+      })
+      .expect(200);
+    expect(search.body.candidates[0]).toMatchObject({
+      groundingMetadata: {
+        groundingChunks: [expect.objectContaining({ web: expect.any(Object) })],
+      },
+    });
+  });
+
+  it.each([
+    [{ inlineData: { mimeType: "image/png", data: "AAA=" } }, "image input"],
+    [{ inlineData: { mimeType: "audio/wav", data: "AAA=" } }, "audio input"],
+    [{ inlineData: { mimeType: "video/mp4", data: "AAA=" } }, "video input"],
+    [{ fileData: { mimeType: "application/pdf", fileUri: "mock://files/file_mock_0001" } }, "file reference"],
+  ])("acknowledges %s", async (part, label) => {
+    const response = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .send({
+        contents: [
+          {
+            role: "user",
+            parts: [part, { text: `Summarize this ${label}.` }],
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(response.body.candidates[0].content.parts[0].text).toContain("mock Gemini model");
+  });
+
+  it("streams function calls and text chunks as parseable SSE", async () => {
+    const functionStream = await collectSse(
+      request(app)
+        .post("/v1beta/models/gemini-1.5-flash:streamGenerateContent")
+        .send({
+          ...baseRequest,
+          tools: [
+            {
+              functionDeclarations: [{ name: "get_order", parameters: { type: "OBJECT" } }],
+            },
+          ],
+        })
+        .expect("Content-Type", /text\/event-stream/)
+        .expect(200)
+    );
+    const functionEvents = parseSseEvents(functionStream.body);
+    expect(functionEvents[0].data).toMatchObject({
+      candidates: [
+        {
+          content: {
+            parts: [{ functionCall: expect.objectContaining({ name: "get_order" }) }],
+          },
+        },
+      ],
+    });
+    expect(functionEvents.at(-1)?.data).toMatchObject({
+      candidates: [
+        {
+          content: {
+            parts: [{ functionCall: expect.objectContaining({ name: "get_order" }) }],
+          },
+        },
+      ],
+    });
+
+    const legacyTextStream = await collectSse(
+      request(app)
+        .post("/gemini/v1/models/gemini-1.5-flash/streamGenerateContent")
+        .send(baseRequest)
+        .expect("Content-Type", /text\/event-stream/)
+        .expect(200)
+    );
+    const textEvents = parseSseEvents(legacyTextStream.body);
+    expect(textEvents.at(-1)?.data).toMatchObject({
+      candidates: [
+        expect.objectContaining({
+          finishReason: "STOP",
+        }),
+      ],
+    });
+    expect(textEvents[0].data).toMatchObject({
+      candidates: [
+        {
+          content: { parts: [expect.objectContaining({ text: expect.any(String) })] },
+        },
+      ],
+    });
+  });
+
+  it("counts tokens for contents and generateContentRequest payloads", async () => {
+    const contentsCount = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:countTokens")
+      .send(baseRequest)
+      .expect(200);
+    expect(contentsCount.body.totalTokens).toBeGreaterThan(0);
+
+    const nestedCount = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:countTokens")
+      .send({ generateContentRequest: { ...baseRequest, systemInstruction: { parts: [{ text: "Be concise." }] } } })
+      .expect(200);
+    expect(nestedCount.body.totalTokens).toBeGreaterThan(contentsCount.body.totalTokens);
+  });
+
+  it("returns Gemini-style validation and injected errors", async () => {
+    const validation = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .send({})
+      .expect(400);
+    expect(validation.body).toEqual({
+      error: {
+        code: 400,
+        message: "Request must contain at least one content item",
+        status: "INVALID_ARGUMENT",
+      },
+    });
+
+    const rateLimit = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .set("x-mock-error", "429")
+      .send(baseRequest)
+      .expect(429);
+    expect(rateLimit.body.error.status).toBe("RESOURCE_EXHAUSTED");
+
+    const unavailable = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent?mock_error=529")
+      .send(baseRequest)
+      .expect(529);
+    expect(unavailable.body.error.status).toBe("UNAVAILABLE");
+
+    const invalidToolArgs = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .set("x-mock-scenario", "invalid_tool_args")
+      .send(baseRequest)
+      .expect(400);
+    expect(invalidToolArgs.body.error).toMatchObject({
+      status: "INVALID_ARGUMENT",
+      message: "Invalid mock tool arguments.",
+    });
+  });
+
+  it("rejects invalid Gemini parts with provider error shape", async () => {
+    const response = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .send({
+        contents: [{ role: "user", parts: [{ text: "Hello", fileData: { fileUri: "mock://file" } }] }],
+      })
+      .expect(400);
+
+    expect(response.body.error).toMatchObject({
+      status: "INVALID_ARGUMENT",
+      message: "part must contain exactly one supported field",
+    });
+  });
+});

--- a/test/contract/helpers.ts
+++ b/test/contract/helpers.ts
@@ -1,0 +1,39 @@
+import request from "supertest";
+
+export type SseEvent = {
+  event?: string;
+  data: unknown;
+};
+
+export function parseSseEvents(payload: string): SseEvent[] {
+  return payload
+    .split(/\n\n/)
+    .map((event) => event.trim())
+    .filter(Boolean)
+    .map((event) => {
+      const lines = event.split(/\n/);
+      const eventName = lines.find((line) => line.startsWith("event: "))?.slice("event: ".length);
+      const data = lines
+        .filter((line) => line.startsWith("data: "))
+        .map((line) => line.slice("data: ".length))
+        .join("\n");
+
+      return {
+        event: eventName,
+        data: data === "[DONE]" ? "[DONE]" : JSON.parse(data),
+      };
+    });
+}
+
+export function collectSse(response: request.Test): request.Test {
+  return response
+    .buffer(true)
+    .parse((res, callback) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      res.on("end", () => callback(null, body));
+    });
+}

--- a/test/contract/mockControls.test.ts
+++ b/test/contract/mockControls.test.ts
@@ -1,0 +1,37 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import app from "../../src/app";
+import { collectSse, parseSseEvents } from "./helpers";
+
+describe("mock control contracts", () => {
+  it("applies endpoint latency from x-mock-latency-ms", async () => {
+    const startedAt = performance.now();
+
+    await request(app).get("/health").set("x-mock-latency-ms", "25").expect(200);
+
+    expect(performance.now() - startedAt).toBeGreaterThanOrEqual(15);
+  });
+
+  it("applies stream chunk delay from x-mock-stream-chunk-ms", async () => {
+    const startedAt = performance.now();
+    const stream = await collectSse(
+      request(app)
+        .post("/v1/chat/completions")
+        .set("x-mock-stream-chunk-ms", "8")
+        .send({
+          model: "gpt-4.1-mini",
+          messages: [{ role: "user", content: "Stream this response." }],
+          stream: true,
+        })
+        .expect("Content-Type", /text\/event-stream/)
+        .expect(200)
+    );
+
+    const elapsedMs = performance.now() - startedAt;
+    const events = parseSseEvents(stream.body);
+
+    expect(events.length).toBeGreaterThan(2);
+    expect(events.at(-1)?.data).toBe("[DONE]");
+    expect(elapsedMs).toBeGreaterThanOrEqual(16);
+  });
+});

--- a/test/contract/openaiChat.test.ts
+++ b/test/contract/openaiChat.test.ts
@@ -1,0 +1,295 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import app from "../../src/app";
+import { collectSse, parseSseEvents } from "./helpers";
+
+const baseRequest = {
+  model: "gpt-4.1-mini",
+  messages: [{ role: "user", content: "Hello" }],
+};
+
+describe("OpenAI Chat Completions modern contract", () => {
+  it("accepts developer role and stores/retrieves/deletes chat completions", async () => {
+    const created = await request(app)
+      .post("/v1/chat/completions")
+      .send({
+        ...baseRequest,
+        messages: [
+          { role: "developer", content: "Answer tersely." },
+          { role: "user", content: "Give a project status." },
+        ],
+        metadata: { suite: "contract" },
+      })
+      .expect(200);
+
+    expect(created.body).toMatchObject({
+      id: expect.stringMatching(/^chatcmpl_mock_/),
+      object: "chat.completion",
+      model: "gpt-4.1-mini",
+      choices: [
+        expect.objectContaining({
+          message: expect.objectContaining({ role: "assistant", content: expect.any(String) }),
+          finish_reason: "stop",
+        }),
+      ],
+      usage: {
+        prompt_tokens: expect.any(Number),
+        completion_tokens: expect.any(Number),
+        total_tokens: expect.any(Number),
+      },
+      metadata: { suite: "contract" },
+    });
+
+    const retrieved = await request(app).get(`/v1/chat/completions/${created.body.id}`).expect(200);
+    expect(retrieved.body.id).toBe(created.body.id);
+
+    const messages = await request(app)
+      .get(`/v1/chat/completions/${created.body.id}/messages`)
+      .expect(200);
+    expect(messages.body).toMatchObject({
+      object: "list",
+      has_more: false,
+      data: expect.arrayContaining([
+        expect.objectContaining({ role: "developer" }),
+        expect.objectContaining({ role: "assistant" }),
+      ]),
+    });
+
+    const updated = await request(app)
+      .post(`/v1/chat/completions/${created.body.id}`)
+      .send({ metadata: { suite: "updated" } })
+      .expect(200);
+    expect(updated.body.metadata).toEqual({ suite: "updated" });
+
+    const deleted = await request(app).delete(`/v1/chat/completions/${created.body.id}`).expect(200);
+    expect(deleted.body).toEqual({
+      id: created.body.id,
+      object: "chat.completion.deleted",
+      deleted: true,
+    });
+    await request(app).get(`/v1/chat/completions/${created.body.id}`).expect(404);
+  });
+
+  it("handles content parts for image, audio, and file inputs", async () => {
+    const cases = [
+      [{ type: "text", text: "Describe this image" }, { type: "image_url", image_url: { url: "mock://image.png" } }],
+      [{ type: "text", text: "Transcribe this audio" }, { type: "input_audio", input_audio: { data: "AAA=", format: "wav" } }],
+      [{ type: "text", text: "Summarize this file" }, { type: "file", file: { file_id: "file_mock_0001" } }],
+    ];
+
+    for (const content of cases) {
+      const response = await request(app)
+        .post("/v1/chat/completions")
+        .send({
+          model: "gpt-4.1-mini",
+          messages: [{ role: "user", content }],
+        })
+        .expect(200);
+
+      expect(response.body.choices[0].message.content).toContain("mock");
+    }
+  });
+
+  it("returns schema-compatible JSON when response_format requests JSON schema", async () => {
+    const response = await request(app)
+      .post("/v1/chat/completions")
+      .send({
+        ...baseRequest,
+        response_format: {
+          type: "json_schema",
+          json_schema: {
+            name: "product_extract",
+            schema: { type: "object" },
+          },
+        },
+      })
+      .expect(200);
+
+    expect(JSON.parse(response.body.choices[0].message.content)).toEqual({
+      name: "UltraWidget",
+      price: 19.99,
+      currency: "USD",
+    });
+  });
+
+  it("returns tool calls and parallel tool calls", async () => {
+    const toolCall = await request(app)
+      .post("/v1/chat/completions")
+      .send({
+        ...baseRequest,
+        tools: [{ type: "function", function: { name: "get_order", parameters: { type: "object" } } }],
+      })
+      .expect(200);
+
+    expect(toolCall.body.choices[0]).toMatchObject({
+      finish_reason: "tool_calls",
+      message: {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: expect.stringMatching(/^call_mock_/),
+            type: "function",
+            function: { name: "get_order", arguments: JSON.stringify({ order_id: "A100" }) },
+          },
+        ],
+      },
+    });
+
+    const parallel = await request(app)
+      .post("/v1/chat/completions")
+      .send({
+        ...baseRequest,
+        parallel_tool_calls: true,
+        tools: [
+          { type: "function", function: { name: "get_order" } },
+          { type: "function", function: { name: "get_weather" } },
+        ],
+      })
+      .expect(200);
+
+    expect(parallel.body.choices[0].message.tool_calls.map((tool: { function: { name: string } }) => tool.function.name)).toEqual([
+      "get_order",
+      "get_weather",
+    ]);
+  });
+
+  it("returns a final text response after tool result messages", async () => {
+    const response = await request(app)
+      .post("/v1/chat/completions")
+      .send({
+        model: "gpt-4.1-mini",
+        messages: [
+          { role: "user", content: "Look up order A100." },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_mock_0001",
+                type: "function",
+                function: { name: "get_order", arguments: '{"order_id":"A100"}' },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            tool_call_id: "call_mock_0001",
+            content: '{"status":"out_for_delivery"}',
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(response.body.choices[0].finish_reason).toBe("stop");
+    expect(response.body.choices[0].message.content).toContain("out_for_delivery");
+  });
+
+  it("streams text chunks with include_usage and streams tool call deltas", async () => {
+    const textStream = await collectSse(
+      request(app)
+        .post("/v1/chat/completions")
+        .send({ ...baseRequest, stream: true, stream_options: { include_usage: true } })
+        .expect("Content-Type", /text\/event-stream/)
+        .expect(200)
+    );
+    const textEvents = parseSseEvents(textStream.body);
+    expect(textEvents.at(-1)?.data).toBe("[DONE]");
+    expect(textEvents.at(-2)?.data).toMatchObject({
+      object: "chat.completion.chunk",
+      choices: [],
+      usage: {
+        prompt_tokens: expect.any(Number),
+        completion_tokens: expect.any(Number),
+        total_tokens: expect.any(Number),
+      },
+    });
+
+    const toolStream = await collectSse(
+      request(app)
+        .post("/v1/chat/completions")
+        .send({
+          ...baseRequest,
+          stream: true,
+          tools: [{ type: "function", function: { name: "get_order" } }],
+        })
+        .expect("Content-Type", /text\/event-stream/)
+        .expect(200)
+    );
+    const toolEvents = parseSseEvents(toolStream.body);
+    expect(toolEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            choices: [
+              expect.objectContaining({
+                delta: expect.objectContaining({
+                  tool_calls: [
+                    expect.objectContaining({
+                      function: expect.objectContaining({ name: "get_order" }),
+                    }),
+                  ],
+                }),
+              }),
+            ],
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("returns OpenAI-style validation and injected errors", async () => {
+    await request(app)
+      .post("/v1/chat/completions")
+      .send({ messages: [{ role: "user", content: "Hello" }] })
+      .expect(400)
+      .expect({
+        error: {
+          message: "Missing required parameter: model",
+          type: "invalid_request_error",
+          code: "missing_parameter",
+        },
+      });
+
+    const invalidRole = await request(app)
+      .post("/v1/chat/completions")
+      .send({ model: "gpt-4.1-mini", messages: [{ role: "bad", content: "Hello" }] })
+      .expect(400);
+    expect(invalidRole.body.error).toMatchObject({
+      message: "messages contains an invalid role",
+      type: "invalid_request_error",
+    });
+
+    const rateLimit = await request(app)
+      .post("/v1/chat/completions")
+      .set("x-mock-error", "429")
+      .send(baseRequest)
+      .expect(429);
+    expect(rateLimit.body.error.type).toBe("rate_limit_error");
+
+    const invalidToolArgs = await request(app)
+      .post("/v1/chat/completions")
+      .set("x-mock-scenario", "invalid_tool_args")
+      .send(baseRequest)
+      .expect(400);
+    expect(invalidToolArgs.body.error).toMatchObject({
+      type: "invalid_request_error",
+      message: "Invalid mock tool arguments.",
+    });
+  });
+
+  it("rejects invalid OpenAI chat content parts with provider error shape", async () => {
+    const response = await request(app)
+      .post("/v1/chat/completions")
+      .send({
+        model: "gpt-4.1-mini",
+        messages: [{ role: "user", content: [{ type: "image_url" }] }],
+      })
+      .expect(400);
+
+    expect(response.body.error).toMatchObject({
+      message: "image_url content part requires image_url",
+      type: "invalid_request_error",
+    });
+  });
+});

--- a/test/contract/openaiResponses.test.ts
+++ b/test/contract/openaiResponses.test.ts
@@ -1,0 +1,256 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import app from "../../src/app";
+import { collectSse, parseSseEvents } from "./helpers";
+
+function createResponse(body: Record<string, unknown>, scenario?: string) {
+  const test = request(app).post("/v1/responses").send({
+    model: "gpt-4.1-mini",
+    input: "Write a one-line project status update.",
+    ...body,
+  });
+
+  return scenario ? test.set("x-mock-scenario", scenario) : test;
+}
+
+describe("OpenAI Responses API contract", () => {
+  it("creates, retrieves, lists input items, and deletes a stored simple response", async () => {
+    const created = await createResponse({ store: true }).expect(200);
+
+    expect(created.body).toMatchObject({
+      id: expect.stringMatching(/^resp_mock_/),
+      object: "response",
+      status: "completed",
+      model: "gpt-4.1-mini",
+      output: [
+        expect.objectContaining({
+          type: "message",
+          status: "completed",
+          role: "assistant",
+          content: [expect.objectContaining({ type: "output_text", text: expect.any(String) })],
+        }),
+      ],
+      usage: expect.objectContaining({
+        input_tokens: expect.any(Number),
+        output_tokens: expect.any(Number),
+        total_tokens: expect.any(Number),
+      }),
+    });
+
+    const retrieved = await request(app).get(`/v1/responses/${created.body.id}`).expect(200);
+    expect(retrieved.body.id).toBe(created.body.id);
+
+    const inputItems = await request(app)
+      .get(`/v1/responses/${created.body.id}/input_items`)
+      .expect(200);
+    expect(inputItems.body).toMatchObject({
+      object: "list",
+      has_more: false,
+      data: [expect.objectContaining({ type: "message", role: "user" })],
+    });
+
+    const deleted = await request(app).delete(`/v1/responses/${created.body.id}`).expect(200);
+    expect(deleted.body).toEqual({
+      id: created.body.id,
+      object: "response.deleted",
+      deleted: true,
+    });
+    await request(app).get(`/v1/responses/${created.body.id}`).expect(404);
+  });
+
+  it("does not persist responses when store is false", async () => {
+    const created = await createResponse({ store: false }).expect(200);
+
+    await request(app).get(`/v1/responses/${created.body.id}`).expect(404);
+  });
+
+  it("cancels queued background responses and rejects cancelling completed responses", async () => {
+    const background = await createResponse({ background: true }).set("x-mock-background", "true").expect(200);
+    expect(background.body.status).toBe("queued");
+
+    const cancelled = await request(app)
+      .post(`/v1/responses/${background.body.id}/cancel`)
+      .expect(200);
+    expect(cancelled.body.status).toBe("cancelled");
+
+    const completed = await createResponse({ store: true }).expect(200);
+    const conflict = await request(app)
+      .post(`/v1/responses/${completed.body.id}/cancel`)
+      .expect(409);
+    expect(conflict.body.error).toMatchObject({
+      type: "conflict_error",
+      code: "conflict",
+    });
+  });
+
+  it("counts input tokens deterministically and compacts context", async () => {
+    const counted = await request(app)
+      .post("/v1/responses/input_tokens")
+      .send({ input: "Hello token counter" })
+      .expect(200);
+    expect(counted.body).toEqual({
+      object: "response.input_tokens",
+      input_tokens: 5,
+    });
+
+    const compacted = await request(app)
+      .post("/v1/responses/compact")
+      .send({ model: "gpt-4.1-mini", input: "Long prior context" })
+      .expect(200);
+    expect(compacted.body).toMatchObject({
+      object: "response",
+      status: "completed",
+      output: [
+        expect.objectContaining({
+          content: [
+            expect.objectContaining({
+              text: "The prior conversation was compacted into a deterministic mock summary.",
+            }),
+          ],
+        }),
+      ],
+    });
+  });
+
+  it("returns deterministic function calls for tool and parallel tool scenarios", async () => {
+    const toolCall = await createResponse(
+      {
+        tools: [
+          {
+            type: "function",
+            name: "get_order",
+            parameters: { type: "object" },
+          },
+        ],
+      },
+      "tool_call"
+    ).expect(200);
+
+    expect(toolCall.body.output).toEqual([
+      expect.objectContaining({
+        type: "function_call",
+        call_id: expect.stringMatching(/^call_mock_/),
+        name: "get_order",
+        arguments: JSON.stringify({ order_id: "A100" }),
+      }),
+    ]);
+
+    const parallelTools = await createResponse(
+      {
+        tools: [
+          { type: "function", name: "get_order" },
+          { type: "function", name: "get_weather" },
+        ],
+      },
+      "parallel_tools"
+    ).expect(200);
+    expect(parallelTools.body.output).toHaveLength(2);
+    expect(parallelTools.body.output.map((item: { name: string }) => item.name)).toEqual([
+      "get_order",
+      "get_weather",
+    ]);
+  });
+
+  it("uses function call output as a deterministic tool result follow-up", async () => {
+    const initial = await createResponse({ tools: [{ type: "function", name: "get_weather" }] }, "tool_call").expect(200);
+    const callId = initial.body.output[0].call_id;
+
+    const followUp = await request(app)
+      .post("/v1/responses")
+      .send({
+        model: "gpt-4.1-mini",
+        previous_response_id: initial.body.id,
+        input: [
+          {
+            type: "function_call_output",
+            call_id: callId,
+            output: '{"temperature_c":27,"condition":"cloudy"}',
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(followUp.body.previous_response_id).toBe(initial.body.id);
+    expect(followUp.body.output[0].content[0].text).toContain("temperature_c");
+  });
+
+  it("returns structured JSON, reasoning metadata, refusal, failed, and cancelled scenarios", async () => {
+    const structured = await createResponse(
+      {
+        text: {
+          format: {
+            type: "json_schema",
+            name: "product_extract",
+            schema: { type: "object" },
+          },
+        },
+      },
+      "structured_json"
+    ).expect(200);
+    expect(JSON.parse(structured.body.output[0].content[0].text)).toEqual({
+      name: "UltraWidget",
+      price: 19.99,
+      currency: "USD",
+    });
+
+    const reasoning = await createResponse({ reasoning: { effort: "medium" } }, "reasoning").expect(200);
+    expect(reasoning.body.reasoning).toMatchObject({ effort: "medium" });
+    expect(reasoning.body.usage.output_tokens_details.reasoning_tokens).toBeGreaterThan(0);
+
+    const refusal = await createResponse({}, "refusal").expect(200);
+    expect(refusal.body.output[0].content[0]).toEqual({
+      type: "refusal",
+      refusal: "I cannot comply with this mock request.",
+    });
+
+    const failed = await createResponse({}, "failed").expect(200);
+    expect(failed.body).toMatchObject({
+      status: "failed",
+      error: { code: "mock_failed" },
+    });
+
+    const cancelled = await createResponse({}, "cancelled").expect(200);
+    expect(cancelled.body.status).toBe("cancelled");
+  });
+
+  it("supports OpenAI-style error injection", async () => {
+    const headerError = await createResponse({}).set("x-mock-error", "429").expect(429);
+    expect(headerError.body.error).toMatchObject({
+      type: "rate_limit_error",
+      code: "rate_limit_exceeded",
+    });
+
+    const queryError = await request(app)
+      .post("/v1/responses?mock_error=529")
+      .send({ model: "gpt-4.1-mini", input: "Hello" })
+      .expect(529);
+    expect(queryError.body.error).toMatchObject({
+      type: "overloaded_error",
+      code: "overloaded",
+    });
+  });
+
+  it("streams Responses API events in provider-compatible order", async () => {
+    const response = await collectSse(
+      createResponse({ stream: true })
+        .expect("Content-Type", /text\/event-stream/)
+        .expect(200)
+    );
+
+    const events = parseSseEvents(response.body);
+    expect(events.map((event) => event.event).filter(Boolean)).toEqual([
+      "response.created",
+      "response.in_progress",
+      "response.output_item.added",
+      "response.content_part.added",
+      "response.output_text.delta",
+      "response.output_text.delta",
+      "response.output_text.delta",
+      "response.output_text.done",
+      "response.content_part.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+    expect(events.at(-1)?.data).toBe("[DONE]");
+  });
+});

--- a/test/contract/supportApis.test.ts
+++ b/test/contract/supportApis.test.ts
@@ -1,0 +1,223 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import app from "../../src/app";
+
+const injectedErrorStatuses = [400, 401, 403, 404, 409, 429, 500, 529] as const;
+
+describe("support API contracts", () => {
+  it("creates OpenAI embeddings for strings and arrays with requested dimensions", async () => {
+    const single = await request(app)
+      .post("/v1/embeddings")
+      .send({ model: "text-embedding-3-small", input: "Hello", dimensions: 3 })
+      .expect(200);
+    expect(single.body).toMatchObject({
+      object: "list",
+      model: "text-embedding-3-small",
+      data: [{ object: "embedding", index: 0 }],
+      usage: {
+        prompt_tokens: expect.any(Number),
+        total_tokens: expect.any(Number),
+      },
+    });
+    expect(single.body.data[0].embedding).toHaveLength(3);
+
+    const multiple = await request(app)
+      .post("/v1/embeddings")
+      .send({ model: "text-embedding-3-small", input: ["Hello", "World"], dimensions: 2 })
+      .expect(200);
+    expect(multiple.body.data).toHaveLength(2);
+    expect(multiple.body.data[1]).toMatchObject({ object: "embedding", index: 1 });
+  });
+
+  it("supports OpenAI image edits and variations with multipart uploads", async () => {
+    const edit = await request(app)
+      .post("/v1/images/edits")
+      .field("n", "2")
+      .field("response_format", "b64_json")
+      .attach("image", Buffer.from("mock image"), "image.png")
+      .expect(200);
+    expect(edit.body.data).toHaveLength(2);
+    expect(edit.body.data[0]).toMatchObject({
+      b64_json: expect.any(String),
+      revised_prompt: "A deterministic mock image edit.",
+    });
+
+    const variation = await request(app)
+      .post("/v1/images/variations")
+      .attach("image", Buffer.from("mock image"), "image.png")
+      .expect(200);
+    expect(variation.body.data[0]).toMatchObject({
+      url: expect.any(String),
+      revised_prompt: "A deterministic mock image variation.",
+    });
+  });
+
+  it("creates, lists, retrieves, and deletes OpenAI file objects", async () => {
+    const created = await request(app)
+      .post("/v1/files")
+      .field("purpose", "assistants")
+      .attach("file", Buffer.from("mock file"), "notes.txt")
+      .expect(200);
+
+    expect(created.body).toMatchObject({
+      id: expect.stringMatching(/^file_mock_/),
+      object: "file",
+      filename: "notes.txt",
+      purpose: "assistants",
+      bytes: expect.any(Number),
+    });
+
+    const listed = await request(app).get("/v1/files").expect(200);
+    expect(listed.body.data).toEqual(expect.arrayContaining([expect.objectContaining({ id: created.body.id })]));
+
+    const retrieved = await request(app).get(`/v1/files/${created.body.id}`).expect(200);
+    expect(retrieved.body.id).toBe(created.body.id);
+
+    const deleted = await request(app).delete(`/v1/files/${created.body.id}`).expect(200);
+    expect(deleted.body).toEqual({ id: created.body.id, object: "file", deleted: true });
+    await request(app).get(`/v1/files/${created.body.id}`).expect(404);
+  });
+
+  it("creates, lists, retrieves, and deletes Anthropic file objects via provider headers", async () => {
+    const created = await request(app)
+      .post("/v1/files")
+      .set("anthropic-version", "2023-06-01")
+      .attach("file", Buffer.from("mock policy"), "policy.pdf")
+      .expect(200);
+
+    expect(created.body).toMatchObject({
+      id: expect.stringMatching(/^file_mock_/),
+      type: "file",
+      filename: "policy.pdf",
+      mime_type: expect.any(String),
+      size_bytes: expect.any(Number),
+    });
+
+    const listed = await request(app)
+      .get("/v1/files")
+      .set("anthropic-version", "2023-06-01")
+      .expect(200);
+    expect(listed.body.data).toEqual(expect.arrayContaining([expect.objectContaining({ id: created.body.id })]));
+
+    const retrieved = await request(app)
+      .get(`/v1/files/${created.body.id}`)
+      .set("anthropic-version", "2023-06-01")
+      .expect(200);
+    expect(retrieved.body.id).toBe(created.body.id);
+
+    const deleted = await request(app)
+      .delete(`/v1/files/${created.body.id}`)
+      .set("anthropic-version", "2023-06-01")
+      .expect(200);
+    expect(deleted.body).toEqual({ id: created.body.id, type: "file_deleted", deleted: true });
+    await request(app).get(`/v1/files/${created.body.id}`).set("anthropic-version", "2023-06-01").expect(404);
+  });
+
+  it("creates, lists, retrieves, and deletes Gemini files", async () => {
+    const uploaded = await request(app)
+      .post("/upload/v1beta/files")
+      .attach("file", Buffer.from("mock invoice"), "invoice.pdf")
+      .expect(200);
+
+    expect(uploaded.body).toMatchObject({
+      name: expect.stringMatching(/^files\/file_mock_/),
+      displayName: "invoice.pdf",
+      uri: expect.stringMatching(/^mock:\/\/files\/file_mock_/),
+      state: "ACTIVE",
+    });
+
+    const listed = await request(app).get("/v1beta/files").expect(200);
+    expect(listed.body.files).toEqual(expect.arrayContaining([expect.objectContaining({ name: uploaded.body.name })]));
+
+    const encodedName = encodeURIComponent(uploaded.body.name);
+    const retrieved = await request(app).get(`/v1beta/files/${encodedName}`).expect(200);
+    expect(retrieved.body.name).toBe(uploaded.body.name);
+
+    await request(app).delete(`/v1beta/files/${encodedName}`).expect(200);
+    await request(app).get(`/v1beta/files/${encodedName}`).expect(404);
+  });
+
+  it("creates, lists, retrieves, deletes, and references Gemini cached contents", async () => {
+    const created = await request(app)
+      .post("/v1beta/cachedContents")
+      .send({
+        model: "models/gemini-1.5-flash",
+        contents: [{ role: "user", parts: [{ text: "Persistent context." }] }],
+        systemInstruction: { parts: [{ text: "Answer concisely." }] },
+      })
+      .expect(200);
+
+    expect(created.body).toMatchObject({
+      name: expect.stringMatching(/^cachedContents\/cached_mock_/),
+      model: "models/gemini-1.5-flash",
+      usageMetadata: { totalTokenCount: expect.any(Number) },
+    });
+
+    const listed = await request(app).get("/v1beta/cachedContents").expect(200);
+    expect(listed.body.cachedContents).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: created.body.name })])
+    );
+
+    const encodedName = encodeURIComponent(created.body.name);
+    const retrieved = await request(app).get(`/v1beta/cachedContents/${encodedName}`).expect(200);
+    expect(retrieved.body.name).toBe(created.body.name);
+
+    const generated = await request(app)
+      .post("/v1beta/models/gemini-1.5-flash:generateContent")
+      .send({
+        cachedContent: created.body.name,
+        contents: [{ role: "user", parts: [{ text: "Continue using cached context." }] }],
+      })
+      .expect(200);
+    expect(generated.body.usageMetadata.totalTokenCount).toBeGreaterThan(0);
+
+    await request(app).delete(`/v1beta/cachedContents/${encodedName}`).expect(200);
+    await request(app).get(`/v1beta/cachedContents/${encodedName}`).expect(404);
+  });
+
+  it.each(injectedErrorStatuses)("injects provider-shaped %i errors on support file APIs", async (status) => {
+    const openai = await request(app)
+      .get("/v1/files")
+      .set("x-mock-error", String(status))
+      .expect(status);
+    expect(openai.body.error).toMatchObject({
+      message: expect.any(String),
+      type: expect.any(String),
+      code: expect.any(String),
+    });
+
+    const anthropic = await request(app)
+      .get("/v1/files")
+      .set("anthropic-version", "2023-06-01")
+      .set("x-mock-error", String(status))
+      .expect(status);
+    expect(anthropic.body).toMatchObject({
+      type: "error",
+      error: {
+        type: expect.any(String),
+        message: expect.any(String),
+      },
+    });
+
+    const gemini = await request(app)
+      .get("/v1beta/files")
+      .set("x-mock-error", String(status))
+      .expect(status);
+    expect(gemini.body.error).toMatchObject({
+      code: status,
+      message: expect.any(String),
+      status: expect.any(String),
+    });
+  });
+
+  it("injects query-string errors on Gemini cached content APIs", async () => {
+    const response = await request(app)
+      .get("/v1beta/cachedContents?mock_error=529")
+      .expect(529);
+
+    expect(response.body.error).toMatchObject({
+      code: 529,
+      status: "UNAVAILABLE",
+    });
+  });
+});

--- a/test/sdk/anthropic.sdk.test.ts
+++ b/test/sdk/anthropic.sdk.test.ts
@@ -1,0 +1,91 @@
+import Anthropic, { toFile } from "@anthropic-ai/sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { SdkServer, runSdkTests, startSdkServer, stopSdkServer } from "./helpers";
+
+describe.skipIf(!runSdkTests)("Anthropic SDK smoke tests", () => {
+  let sdkServer: SdkServer;
+  let client: Anthropic;
+
+  beforeAll(async () => {
+    sdkServer = await startSdkServer();
+    client = new Anthropic({
+      apiKey: "sk-ant-mock",
+      baseURL: sdkServer.baseUrl,
+      maxRetries: 0,
+    });
+  });
+
+  afterAll(async () => {
+    await stopSdkServer(sdkServer?.server);
+  });
+
+  it("creates Messages API text, stream, tool use, and tool result follow-up responses", async () => {
+    const message = await client.messages.create({
+      model: "claude-sonnet-4-5",
+      max_tokens: 256,
+      messages: [{ role: "user", content: "Hello" }],
+    });
+    expect(message.content[0].type).toBe("text");
+
+    const stream = client.messages.stream({
+      model: "claude-sonnet-4-5",
+      max_tokens: 256,
+      messages: [{ role: "user", content: "Hello" }],
+    });
+    const finalMessage = await stream.finalMessage();
+    expect(finalMessage.stop_reason).toBe("end_turn");
+
+    const toolUse = await client.messages.create({
+      model: "claude-sonnet-4-5",
+      max_tokens: 256,
+      messages: [{ role: "user", content: "Look up order A100." }],
+      tools: [{ name: "get_order", input_schema: { type: "object" } }],
+    });
+    const toolBlock = toolUse.content.find((block) => block.type === "tool_use");
+    expect(toolBlock).toMatchObject({ type: "tool_use", name: "get_order" });
+
+    const followUp = await client.messages.create({
+      model: "claude-sonnet-4-5",
+      max_tokens: 256,
+      messages: [
+        { role: "user", content: "Look up order A100." },
+        { role: "assistant", content: toolUse.content },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: toolBlock?.type === "tool_use" ? toolBlock.id : "toolu_mock_0001",
+              content: '{"status":"out_for_delivery"}',
+            },
+          ],
+        },
+      ],
+    });
+    expect(followUp.content[0]).toMatchObject({ type: "text" });
+  });
+
+  it("counts tokens and manages beta files when supported by the SDK", async () => {
+    const tokenCount = await client.messages.countTokens({
+      model: "claude-sonnet-4-5",
+      messages: [{ role: "user", content: "Hello" }],
+    });
+    expect(tokenCount.input_tokens).toBeGreaterThan(0);
+
+    const betaFiles = client.beta?.files;
+    if (!betaFiles) {
+      return;
+    }
+
+    const uploaded = await betaFiles.upload({
+      file: await toFile(Buffer.from("mock policy"), "policy.txt"),
+    });
+    expect(uploaded.id).toMatch(/^file_mock_/);
+
+    const listed = await betaFiles.list();
+    expect(listed.data.some((file) => file.id === uploaded.id)).toBe(true);
+
+    const deleted = await betaFiles.delete(uploaded.id);
+    expect(deleted.id).toBe(uploaded.id);
+  });
+});

--- a/test/sdk/googleGenAi.sdk.test.ts
+++ b/test/sdk/googleGenAi.sdk.test.ts
@@ -1,0 +1,127 @@
+import { GoogleGenAI } from "@google/genai";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { SdkServer, runSdkTests, startSdkServer, stopSdkServer } from "./helpers";
+
+describe.skipIf(!runSdkTests)("Google GenAI SDK smoke tests", () => {
+  let sdkServer: SdkServer;
+  let client: GoogleGenAI;
+
+  beforeAll(async () => {
+    sdkServer = await startSdkServer();
+    client = new GoogleGenAI({
+      apiKey: "gemini-mock",
+      httpOptions: {
+        baseUrl: sdkServer.baseUrl,
+        apiVersion: "v1beta",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await stopSdkServer(sdkServer?.server);
+  });
+
+  it("generates text, streams text, calls functions, and returns structured output", async () => {
+    const generated = await client.models.generateContent({
+      model: "gemini-1.5-flash",
+      contents: "Hello",
+    });
+    expect(generated.text).toEqual(expect.any(String));
+
+    const stream = await client.models.generateContentStream({
+      model: "gemini-1.5-flash",
+      contents: "Hello",
+    });
+    const streamTexts: string[] = [];
+    for await (const chunk of stream) {
+      if (chunk.text) {
+        streamTexts.push(chunk.text);
+      }
+    }
+    expect(streamTexts.join("")).toContain("Gemini mock");
+
+    const functionCall = await client.models.generateContent({
+      model: "gemini-1.5-flash",
+      contents: "Look up order A100.",
+      config: {
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: "get_order",
+                parameters: { type: "OBJECT", properties: { order_id: { type: "STRING" } } },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(functionCall.functionCalls?.[0]).toMatchObject({ name: "get_order" });
+
+    const structured = await client.models.generateContent({
+      model: "gemini-1.5-flash",
+      contents: "Extract product name and price from: UltraWidget costs $19.99.",
+      config: {
+        responseMimeType: "application/json",
+        responseSchema: { type: "OBJECT" },
+      },
+    });
+    expect(JSON.parse(structured.text || "{}")).toEqual({
+      name: "UltraWidget",
+      price: 19.99,
+      currency: "USD",
+    });
+  });
+
+  it("counts tokens and manages files and caches", async () => {
+    const count = await client.models.countTokens({
+      model: "gemini-1.5-flash",
+      contents: "Hello",
+    });
+    expect(count.totalTokens).toBeGreaterThan(0);
+
+    const file = await client.files.upload({
+      file: new Blob(["mock invoice"], { type: "text/plain" }),
+      config: {
+        mimeType: "text/plain",
+        displayName: "invoice.txt",
+      },
+    });
+    expect(file.name).toMatch(/^files\/file_mock_/);
+
+    const listedFiles = await client.files.list();
+    const fileNames: string[] = [];
+    for await (const item of listedFiles) {
+      if (item.name) {
+        fileNames.push(item.name);
+      }
+    }
+    expect(fileNames).toContain(file.name);
+
+    if (file.name) {
+      await client.files.delete({ name: file.name });
+    }
+
+    const cached = await client.caches.create({
+      model: "gemini-1.5-flash",
+      config: {
+        contents: [{ role: "user", parts: [{ text: "Persistent context." }] }],
+        systemInstruction: { parts: [{ text: "Answer concisely." }] },
+      },
+    });
+    expect(cached.name).toMatch(/^cachedContents\/cached_mock_/);
+
+    const listed = await client.caches.list();
+    const cachedNames: string[] = [];
+    for await (const item of listed) {
+      if (item.name) {
+        cachedNames.push(item.name);
+      }
+    }
+    expect(cachedNames).toContain(cached.name);
+
+    if (cached.name) {
+      await client.caches.delete({ name: cached.name });
+    }
+  });
+});

--- a/test/sdk/helpers.ts
+++ b/test/sdk/helpers.ts
@@ -1,0 +1,41 @@
+import { Server } from "node:http";
+import app from "../../src/app";
+
+export const runSdkTests = process.env.RUN_SDK_TESTS === "1";
+
+export type SdkServer = {
+  server: Server;
+  baseUrl: string;
+};
+
+export async function startSdkServer(): Promise<SdkServer> {
+  const server = await new Promise<Server>((resolve) => {
+    const listener = app.listen(0, "127.0.0.1", () => resolve(listener));
+  });
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    throw new Error("Unable to resolve SDK smoke test server address");
+  }
+
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+export async function stopSdkServer(server: Server | undefined): Promise<void> {
+  if (!server) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/test/sdk/openai.sdk.test.ts
+++ b/test/sdk/openai.sdk.test.ts
@@ -1,0 +1,94 @@
+import OpenAI, { toFile } from "openai";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { SdkServer, runSdkTests, startSdkServer, stopSdkServer } from "./helpers";
+
+describe.skipIf(!runSdkTests)("OpenAI SDK smoke tests", () => {
+  let sdkServer: SdkServer;
+  let client: OpenAI;
+
+  beforeAll(async () => {
+    sdkServer = await startSdkServer();
+    client = new OpenAI({
+      apiKey: "sk-mock",
+      baseURL: `${sdkServer.baseUrl}/v1`,
+      maxRetries: 0,
+    });
+  });
+
+  afterAll(async () => {
+    await stopSdkServer(sdkServer?.server);
+  });
+
+  it("creates Responses API text, stream, and tool call responses", async () => {
+    const response = await client.responses.create({
+      model: "gpt-4.1-mini",
+      input: "Write a one-line project status update.",
+    });
+    expect(response.id).toMatch(/^resp_mock_/);
+
+    const stream = await client.responses.create({
+      model: "gpt-4.1-mini",
+      input: "Stream a status update.",
+      stream: true,
+    });
+    const streamTypes: string[] = [];
+    for await (const event of stream) {
+      streamTypes.push(event.type);
+    }
+    expect(streamTypes).toContain("response.completed");
+
+    const toolCall = await client.responses.create({
+      model: "gpt-4.1-mini",
+      input: "Look up order A100.",
+      tools: [
+        {
+          type: "function",
+          name: "get_order",
+          parameters: { type: "object", properties: { order_id: { type: "string" } } },
+        },
+      ],
+    });
+    expect(toolCall.output[0]).toMatchObject({ type: "function_call", name: "get_order" });
+  });
+
+  it("creates Chat Completions text and include_usage streams", async () => {
+    const completion = await client.chat.completions.create({
+      model: "gpt-4.1-mini",
+      messages: [{ role: "user", content: "Hello" }],
+    });
+    expect(completion.choices[0].message.content).toEqual(expect.any(String));
+
+    const stream = await client.chat.completions.create({
+      model: "gpt-4.1-mini",
+      messages: [{ role: "user", content: "Hello" }],
+      stream: true,
+      stream_options: { include_usage: true },
+    });
+    let sawUsage = false;
+    for await (const chunk of stream) {
+      sawUsage = sawUsage || Boolean(chunk.usage);
+    }
+    expect(sawUsage).toBe(true);
+  });
+
+  it("creates embeddings and manages files", async () => {
+    const embedding = await client.embeddings.create({
+      model: "text-embedding-3-small",
+      input: "Hello",
+      dimensions: 4,
+    });
+    expect(embedding.data[0].embedding).toHaveLength(4);
+
+    const file = await client.files.create({
+      file: await toFile(Buffer.from("mock file"), "sdk.txt"),
+      purpose: "assistants",
+    });
+    expect(file.id).toMatch(/^file_mock_/);
+
+    const list = await client.files.list();
+    expect(list.data.some((item) => item.id === file.id)).toBe(true);
+
+    const deleted = await client.files.delete(file.id);
+    expect(deleted.deleted).toBe(true);
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,3 @@
+import { vi } from "vitest";
+
+vi.spyOn(console, "log").mockImplementation(() => {});

--- a/test/unit/core/idFactory.test.ts
+++ b/test/unit/core/idFactory.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { IdFactory } from "../../../src/core/state/idFactory";
+
+describe("IdFactory", () => {
+  it("creates stable IDs for the same seed and counter path", () => {
+    const first = new IdFactory("contract seed");
+    const second = new IdFactory("contract seed");
+
+    expect(first.next("response", "responses.create")).toBe("resp_mock_contract_seed_0001");
+    expect(first.next("response", "responses.create")).toBe("resp_mock_contract_seed_0002");
+    expect(second.next("response", "responses.create")).toBe("resp_mock_contract_seed_0001");
+  });
+
+  it("keeps independent counters per kind and path", () => {
+    const factory = new IdFactory("alpha");
+
+    expect(factory.next("response", "a")).toBe("resp_mock_alpha_0001");
+    expect(factory.next("response", "b")).toBe("resp_mock_alpha_0001");
+    expect(factory.next("message", "a")).toBe("msg_mock_alpha_0001");
+  });
+
+  it("uses process-local counters when seed is omitted", () => {
+    const first = new IdFactory();
+    const second = new IdFactory();
+
+    const firstId = first.next("file", "uploads");
+    const secondId = second.next("file", "uploads");
+
+    expect(firstId).toMatch(/^file_mock_\d{4}$/);
+    expect(secondId).toMatch(/^file_mock_\d{4}$/);
+    expect(firstId).not.toBe(secondId);
+  });
+});

--- a/test/unit/core/memoryStore.test.ts
+++ b/test/unit/core/memoryStore.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { MemoryStateStore } from "../../../src/core/state/memoryStore";
+
+describe("MemoryStateStore", () => {
+  it("creates, retrieves, updates, lists, deletes, and clears records", () => {
+    const store = new MemoryStateStore();
+
+    store.create("responses", { id: "resp_mock_0001", provider: "openai", status: "completed" });
+    store.create("responses", { id: "resp_mock_0002", provider: "openai", status: "failed" });
+
+    expect(store.get("responses", "resp_mock_0001")).toMatchObject({ status: "completed" });
+    expect(store.update("responses", "resp_mock_0001", { status: "cancelled" })).toMatchObject({
+      id: "resp_mock_0001",
+      status: "cancelled",
+    });
+    expect(store.list("responses", { provider: "openai" })).toHaveLength(2);
+    expect(store.list("responses", (record) => record.status === "failed")).toEqual([
+      expect.objectContaining({ id: "resp_mock_0002" }),
+    ]);
+    expect(store.delete("responses", "resp_mock_0002")).toBe(true);
+    expect(store.get("responses", "resp_mock_0002")).toBeUndefined();
+
+    store.clear("responses");
+    expect(store.list("responses")).toEqual([]);
+  });
+});

--- a/test/unit/core/providerErrors.test.ts
+++ b/test/unit/core/providerErrors.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { getInjectedProviderError } from "../../../src/core/errors/errorInjector";
+import { buildProviderError, InjectableErrorStatus } from "../../../src/core/errors/providerErrors";
+import { ProviderName } from "../../../src/core/scenarioEngine";
+
+const statuses: InjectableErrorStatus[] = [400, 401, 403, 404, 409, 429, 500, 529];
+
+describe("Provider error builders", () => {
+  it.each(statuses)("builds OpenAI-compatible %i errors", (status) => {
+    const error = buildProviderError("openai", status, "mock failure", "model");
+
+    expect(error.status).toBe(status);
+    expect(error.body).toMatchObject({
+      error: {
+        message: "mock failure",
+        param: "model",
+        type: expect.any(String),
+        code: expect.any(String),
+      },
+    });
+  });
+
+  it.each(statuses)("builds Anthropic-compatible %i errors", (status) => {
+    const error = buildProviderError("anthropic", status, "mock failure");
+
+    expect(error).toMatchObject({
+      status,
+      body: {
+        type: "error",
+        error: {
+          type: expect.any(String),
+          message: "mock failure",
+        },
+      },
+    });
+  });
+
+  it.each(statuses)("builds Gemini-compatible %i errors", (status) => {
+    const error = buildProviderError("gemini", status, "mock failure");
+
+    expect(error).toMatchObject({
+      status,
+      body: {
+        error: {
+          code: status,
+          message: "mock failure",
+          status: expect.any(String),
+        },
+      },
+    });
+  });
+
+  it.each<ProviderName>(["openai", "anthropic", "gemini"])(
+    "injects provider errors from headers and query for %s",
+    (provider) => {
+      expect(
+        getInjectedProviderError({
+          provider,
+          headers: { "x-mock-error": "429" },
+          query: {},
+        })?.status
+      ).toBe(429);
+      expect(
+        getInjectedProviderError({
+          provider,
+          headers: {},
+          query: { mock_error: "529" },
+        })?.status
+      ).toBe(529);
+    }
+  );
+});

--- a/test/unit/core/scenarioEngine.test.ts
+++ b/test/unit/core/scenarioEngine.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { selectScenario, ScenarioInput } from "../../../src/core/scenarioEngine";
+
+function scenarioInput(input: Partial<ScenarioInput>): ScenarioInput {
+  return {
+    provider: "openai",
+    endpoint: "/v1/responses",
+    method: "POST",
+    headers: {},
+    query: {},
+    body: {},
+    ...input,
+  };
+}
+
+describe("ScenarioEngine", () => {
+  it("prioritizes forced mock errors over explicit scenarios and request shape", () => {
+    const selection = selectScenario(
+      scenarioInput({
+        headers: {
+          "x-mock-error": "429",
+          "x-mock-scenario": "structured_json",
+        },
+        body: { stream: true },
+      })
+    );
+
+    expect(selection).toMatchObject({
+      scenario: "rate_limit",
+      forcedError: 429,
+    });
+  });
+
+  it("prioritizes explicit scenarios over inferred request shape", () => {
+    const selection = selectScenario(
+      scenarioInput({
+        headers: { "x-mock-scenario": "refusal" },
+        body: { stream: true, tools: [{ type: "function", name: "lookup" }] },
+      })
+    );
+
+    expect(selection.scenario).toBe("refusal");
+  });
+
+  it("reads query controls for scenario, seed, latency, and stream chunk delay", () => {
+    const selection = selectScenario(
+      scenarioInput({
+        query: {
+          mock_scenario: "structured_json",
+          mock_seed: "contract-1",
+          mock_latency_ms: "25",
+          mock_stream_chunk_ms: "3",
+        },
+      })
+    );
+
+    expect(selection).toMatchObject({
+      scenario: "structured_json",
+      seed: "contract-1",
+      latencyMs: 25,
+      streamChunkMs: 3,
+    });
+  });
+
+  it("infers scenarios from request shape", () => {
+    expect(selectScenario(scenarioInput({ body: { stream: true } })).scenario).toBe("stream_text");
+    expect(
+      selectScenario(
+        scenarioInput({
+          body: { input: [{ type: "function_call_output", call_id: "call_mock_0001", output: "{}" }] },
+        })
+      ).scenario
+    ).toBe("tool_result");
+    expect(
+      selectScenario(
+        scenarioInput({
+          body: { tools: [{ type: "function", name: "get_order" }] },
+        })
+      ).scenario
+    ).toBe("tool_call");
+    expect(
+      selectScenario(
+        scenarioInput({
+          body: { tools: [{ type: "function", name: "a" }, { type: "function", name: "b" }] },
+        })
+      ).scenario
+    ).toBe("parallel_tools");
+    expect(
+      selectScenario(
+        scenarioInput({
+          body: { text: { format: { type: "json_schema" } } },
+        })
+      ).scenario
+    ).toBe("structured_json");
+    expect(
+      selectScenario(
+        scenarioInput({
+          body: { input: [{ type: "input_image", image_url: "mock://image.png" }] },
+        })
+      ).scenario
+    ).toBe("vision");
+    expect(
+      selectScenario(
+        scenarioInput({
+          body: { contents: [{ parts: [{ inlineData: { mimeType: "audio/wav", data: "AAA=" } }] }] },
+        })
+      ).scenario
+    ).toBe("multimodal_audio");
+    expect(
+      selectScenario(
+        scenarioInput({
+          body: { contents: [{ parts: [{ inlineData: { mimeType: "video/mp4", data: "AAA=" } }] }] },
+        })
+      ).scenario
+    ).toBe("multimodal_video");
+    expect(
+      selectScenario(
+        scenarioInput({
+          body: { contents: [{ parts: [{ fileData: { fileUri: "mock://files/file_mock_0001" } }] }] },
+        })
+      ).scenario
+    ).toBe("file_reference");
+  });
+
+  it("infers scenarios from model name hints before falling back to simple text", () => {
+    expect(selectScenario(scenarioInput({ model: "mock-thinking-model" })).scenario).toBe("thinking");
+    expect(selectScenario(scenarioInput({ model: "mock-json-model" })).scenario).toBe("structured_json");
+    expect(selectScenario(scenarioInput({ model: "mock-refusal-model" })).scenario).toBe("refusal");
+    expect(selectScenario(scenarioInput({ model: "plain-model" })).scenario).toBe("simple_text");
+  });
+});

--- a/test/unit/core/sse.test.ts
+++ b/test/unit/core/sse.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { anthropicEvent, anthropicMessageStop } from "../../../src/core/sse/anthropicSse";
+import { geminiData, geminiDone, encodeGeminiSse } from "../../../src/core/sse/geminiSse";
+import { encodeOpenAISse, openAIDone, openAIEvent } from "../../../src/core/sse/openaiSse";
+import { splitSseFrames } from "../../../src/core/sse/streamWriter";
+
+describe("provider SSE encoders", () => {
+  it("formats OpenAI named events and terminal done markers", () => {
+    expect(openAIEvent("response.created", { type: "response.created" })).toBe(
+      'event: response.created\ndata: {"type":"response.created"}\n\n'
+    );
+    expect(openAIDone()).toBe("data: [DONE]\n\n");
+    expect(encodeOpenAISse([{ data: { id: "chatcmpl_mock_0001" } }])).toContain("data: [DONE]");
+  });
+
+  it("formats Anthropic named events and message_stop terminal event", () => {
+    expect(anthropicEvent("content_block_delta", { type: "content_block_delta" })).toBe(
+      'event: content_block_delta\ndata: {"type":"content_block_delta"}\n\n'
+    );
+    expect(anthropicMessageStop()).toBe('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+  });
+
+  it("formats Gemini data chunks and terminal done markers", () => {
+    expect(geminiData({ responseId: "gemini_mock_0001" })).toBe(
+      'data: {"responseId":"gemini_mock_0001"}\n\n'
+    );
+    expect(geminiDone()).toBe("data: [DONE]\n\n");
+    expect(encodeGeminiSse([{ candidates: [] }])).toBe('data: {"candidates":[]}\n\ndata: [DONE]\n\n');
+  });
+
+  it("splits encoded SSE payloads without dropping frame terminators", () => {
+    expect(splitSseFrames('data: {"a":1}\n\ndata: [DONE]\n\n')).toEqual([
+      'data: {"a":1}\n\n',
+      "data: [DONE]\n\n",
+    ]);
+  });
+});

--- a/test/unit/core/usageAndFixtures.test.ts
+++ b/test/unit/core/usageAndFixtures.test.ts
@@ -15,7 +15,7 @@ describe("usage builders and fixtures", () => {
       input_tokens_details: { cached_tokens: 0 },
       output_tokens: 2,
       output_tokens_details: { reasoning_tokens: 2 },
-      total_tokens: 6,
+      total_tokens: 4,
     });
     expect(buildOpenAIChatUsage("hello", "world")).toEqual({
       prompt_tokens: 2,

--- a/test/unit/core/usageAndFixtures.test.ts
+++ b/test/unit/core/usageAndFixtures.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { matchFixture } from "../../../src/core/fixtures/fixtureMatcher";
+import { FixtureStore } from "../../../src/core/fixtures/fixtureStore";
+import {
+  buildAnthropicUsage,
+  buildGeminiUsage,
+  buildOpenAIChatUsage,
+  buildOpenAIResponsesUsage,
+} from "../../../src/core/usage/usageBuilder";
+
+describe("usage builders and fixtures", () => {
+  it("builds deterministic approximate usage for each provider", () => {
+    expect(buildOpenAIResponsesUsage("hello", "world", 2)).toEqual({
+      input_tokens: 2,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens: 2,
+      output_tokens_details: { reasoning_tokens: 2 },
+      total_tokens: 6,
+    });
+    expect(buildOpenAIChatUsage("hello", "world")).toEqual({
+      prompt_tokens: 2,
+      completion_tokens: 2,
+      total_tokens: 4,
+    });
+    expect(buildAnthropicUsage("hello", "world")).toEqual({ input_tokens: 2, output_tokens: 2 });
+    expect(buildGeminiUsage("hello", "world")).toEqual({
+      promptTokenCount: 2,
+      candidatesTokenCount: 2,
+      totalTokenCount: 4,
+    });
+  });
+
+  it("matches exact fixtures before falling back to simple_text", () => {
+    const store = new FixtureStore();
+    store.register({
+      provider: "openai",
+      endpoint: "responses",
+      scenario: "simple_text",
+      data: { text: "fallback" },
+    });
+    store.register({
+      provider: "openai",
+      endpoint: "responses",
+      scenario: "tool_call",
+      data: { tool: "exact" },
+    });
+
+    expect(
+      matchFixture<{ tool: string }>(store, {
+        provider: "openai",
+        endpoint: "responses",
+        scenario: "tool_call",
+      })?.data
+    ).toEqual({ tool: "exact" });
+    expect(
+      matchFixture<{ text: string }>(store, {
+        provider: "openai",
+        endpoint: "responses",
+        scenario: "refusal",
+      })?.data
+    ).toEqual({ text: "fallback" });
+  });
+});

--- a/test/unit/core/validation.test.ts
+++ b/test/unit/core/validation.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateAnthropicCountTokensRequest,
+  validateAnthropicMessageRequest,
+} from "../../../src/core/validation/anthropicSchemas";
+import {
+  validateGeminiCountTokensRequest,
+  validateGeminiGenerateContentRequest,
+} from "../../../src/core/validation/geminiSchemas";
+import {
+  validateOpenAIChatCompletionRequest,
+  validateOpenAIEmbeddingsRequest,
+  validateOpenAIResponsesRequest,
+} from "../../../src/core/validation/openaiSchemas";
+
+describe("core provider validation schemas", () => {
+  it("validates OpenAI chat, responses, and embeddings requests", () => {
+    expect(
+      validateOpenAIChatCompletionRequest({
+        model: "gpt-4.1-mini",
+        messages: [
+          { role: "developer", content: "Be concise." },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Describe this image." },
+              { type: "image_url", image_url: { url: "mock://image.png" } },
+            ],
+          },
+        ],
+        tools: [{ type: "function", function: { name: "get_order" } }],
+        response_format: { type: "json_schema" },
+      })
+    ).toEqual({ ok: true });
+
+    expect(
+      validateOpenAIChatCompletionRequest({
+        model: "gpt-4.1-mini",
+        messages: [{ role: "bad", content: "Hello" }],
+      })
+    ).toMatchObject({ ok: false, issue: { message: "messages contains an invalid role" } });
+
+    expect(
+      validateOpenAIResponsesRequest({
+        input: "Hello",
+        text: { format: { type: "json_schema" } },
+        tools: [{ type: "function", name: "get_order" }],
+      })
+    ).toEqual({ ok: true });
+    expect(validateOpenAIResponsesRequest({ tools: [{ type: "function" }] })).toMatchObject({
+      ok: false,
+      issue: { message: "function tool requires name" },
+    });
+
+    expect(
+      validateOpenAIEmbeddingsRequest({
+        model: "text-embedding-3-small",
+        input: ["Hello", "World"],
+        dimensions: 4,
+        encoding_format: "base64",
+      })
+    ).toEqual({ ok: true });
+    expect(validateOpenAIEmbeddingsRequest({ model: "text-embedding-3-small", input: "Hello", dimensions: 0 })).toMatchObject({
+      ok: false,
+      issue: { message: "dimensions must be an integer between 1 and 2048" },
+    });
+  });
+
+  it("validates Anthropic message and token-count requests", () => {
+    expect(
+      validateAnthropicMessageRequest({
+        model: "claude-sonnet-4-5",
+        max_tokens: 256,
+        messages: [
+          { role: "user", content: "Look up order A100." },
+          {
+            role: "assistant",
+            content: [{ type: "tool_use", id: "toolu_mock_0001", name: "get_order", input: { order_id: "A100" } }],
+          },
+          {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "toolu_mock_0001", content: "{}" }],
+          },
+        ],
+        thinking: { type: "enabled", budget_tokens: 1024 },
+      })
+    ).toEqual({ ok: true });
+
+    expect(
+      validateAnthropicMessageRequest({
+        model: "claude-sonnet-4-5",
+        max_tokens: 256,
+        messages: [{ role: "user", content: [{ type: "image" }] }],
+      })
+    ).toMatchObject({ ok: false, issue: { message: "image block requires source" } });
+
+    expect(
+      validateAnthropicCountTokensRequest({
+        model: "claude-sonnet-4-5",
+        messages: [{ role: "user", content: "Hello" }],
+        tools: [{ name: "get_order", input_schema: { type: "object" } }],
+      })
+    ).toEqual({ ok: true });
+  });
+
+  it("validates Gemini generateContent and countTokens requests", () => {
+    expect(
+      validateGeminiGenerateContentRequest({
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Hello" }, { inlineData: { mimeType: "image/png", data: "AAA=" } }],
+          },
+        ],
+        tools: [{ functionDeclarations: [{ name: "get_order" }] }],
+        generationConfig: { responseMimeType: "application/json" },
+      })
+    ).toEqual({ ok: true });
+
+    expect(
+      validateGeminiGenerateContentRequest({
+        contents: [{ role: "user", parts: [{ text: "Hello", fileData: { fileUri: "mock://file" } }] }],
+      })
+    ).toMatchObject({ ok: false, issue: { message: "part must contain exactly one supported field" } });
+
+    expect(
+      validateGeminiGenerateContentRequest({
+        contents: [
+          { role: "model", parts: [{ functionCall: { id: "fc_mock_0001", name: "get_order", args: {} } }] },
+          {
+            role: "user",
+            parts: [{ functionResponse: { id: "fc_mock_other", name: "get_order", response: {} } }],
+          },
+        ],
+      })
+    ).toMatchObject({
+      ok: false,
+      issue: { message: "functionResponse id does not match a previous functionCall id" },
+    });
+
+    expect(
+      validateGeminiCountTokensRequest({
+        generateContentRequest: {
+          contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+        },
+      })
+    ).toEqual({ ok: true });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    setupFiles: ["./test/setup.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Add deterministic shared mock infrastructure for scenarios, provider-shaped errors, SSE formatting, state, usage, validation, mock controls, and endpoint catalog output.
- Expand OpenAI-compatible coverage with Responses API, modern Chat Completions state/stream/tool flows, embeddings, images, and files.
- Add Anthropic-compatible Messages, streaming/tool/thinking flows, token counting, files, and provider-dispatched models.
- Add Gemini-compatible GenerateContent, streaming, function/tool loops, code/search mocks, files, cached contents, countTokens, and SDK resumable file upload support.
- Add offline contract/unit tests, gated SDK smoke tests, CI, changelog, fixture seeds, and updated English/Chinese documentation plus CLI startup hints.

## Verification
- npm run build
- npm run lint
- npm test
- npm test -- test/contract/baseline.test.ts
- RUN_SDK_TESTS=1 npm test -- test/sdk
- Manual CLI banner check with node dist/cli.js -p 3106 -H 127.0.0.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gemini, Anthropic, and OpenAI-compatible endpoints, SSE streaming, file/cached-content APIs, token counting, and deterministic mock scenarios.
  * CI workflow added to run tests, build, and lint on push/PR.

* **Improvements**
  * Expanded docs and endpoint catalog with concrete curl examples and SDK guidance.
  * Added mock controls: latency, stream-chunk delays, error injection, and deterministic IDs/state.

* **Tests**
  * Large contract/unit/SDK test suites and deterministic fixtures added to validate behaviors and streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->